### PR TITLE
first attempt on integrating protractor

### DIFF
--- a/src/interop/protractor/get_tests.js
+++ b/src/interop/protractor/get_tests.js
@@ -1,0 +1,54 @@
+var fs = require("fs");
+var path = require("path");
+var settings = require("../../settings");
+
+var protractorConfigFilePath = settings.nightwatchConfigFilePath;
+
+require('songbird')
+
+module.exports = function() {
+    var data;
+
+    try {
+        data = fs.readFileSync(protractorConfigFilePath, "utf8");
+        console.log("Magellan-protractor test iterator found protractor configuration at: " + protractorConfigFilePath);
+    } catch (e) {
+        var error = "Magellan-protractor test iterator: Error reading protractor configuration at " + protractorConfigFilePath;
+        console.error(error);
+        return;
+    }
+
+    // the file protractorConfigFilePath = conf.js  has an export.config, and not straight JSON, so I cannot parse it the way nightwatch version does
+    // for now I am using a similar method like you have done for nightwatch.
+
+    var protractorConfig = JSON.parse(data);
+    var srcFolders = protractorConfig.specs;
+
+    // var files = fs.readdirSync(srcFolders);
+    // console.log('files'+ files);
+
+    // fs.promise.readdir(srcFolders).then(function(result) {
+    //     console.log(" File List retrieved: " + result);
+    // });
+
+ var allFiles = [];
+
+    srcFolders.forEach(function (folder) {
+    var files = fs.readdirSync(path.normalize(folder));
+    if (files.length > 0) {
+      allFiles = allFiles.concat(files.map(function (f) {
+        return path.normalize(folder) + "/" + f;
+      }));
+    }
+  });
+
+  // Ensure we scan for JS only, ignoring README files, etc.
+  allFiles = allFiles.filter(function (f) {
+    return (f.indexOf(".js") === f.length - 3);
+  }).map(function (f) {
+    return f.trim();
+  });
+
+return allFiles;
+
+};

--- a/src/interop/protractor/protractor.js
+++ b/src/interop/protractor/protractor.js
@@ -1,0 +1,6 @@
+{
+    "seleniumAddress": "http: //localhost: 4444/wd/hub",
+    "specs": [
+        "test/integration/"
+    ]
+}

--- a/test/integration/test_walmart.js
+++ b/test/integration/test_walmart.js
@@ -1,0 +1,6 @@
+describe('Walmart test', function() {
+  it('should open the page and assert on Logo', function() {
+    browser.get('https://www.walmart.com');
+    expect(by.css('.js-logo a').getText()).toContain('Walmart');
+  });
+});


### PR DESCRIPTION
This is still a work in progress. Wanted to send it your way before I leave for vacation.  

Todo : 
1. use acorn to parse the test/spec files
2. remove duplicate code from get_tests.js. May be find a cleaner and concise way to read spec files
3. the protractor library needs the conf.js file in exports.config. Right now I have mimicked the nightwatch way by creating a JSON, but this will not work in protractor.
