### PR TITLE
Initial mocha/rowdy support

### DIFF
--- a/bin/magellan
+++ b/bin/magellan
@@ -22,6 +22,8 @@ var clc = require("cli-color");
 var browsers = require("../src/sauce/browsers");
 
 var isSauce = margs.argv.sauce ? true : false;
+var isNodeBased = margs.argv.framework === "mocha";
+
 var debug = margs.argv.debug || false;
 var useSerialMode = margs.argv.serial;
 var MAX_TEST_ATTEMPTS = parseInt(margs.argv.max_test_attempts) || 3;
@@ -45,12 +47,6 @@ if (margs.argv.list_browsers) {
     console.log("Couldn't fetch browsers. Error: ", err);
   });
   return;
-}
-
-// Basic Mocha/Appium integration support check
-if (margs.argv.framework === "mocha" && !isSauce) {
-  console.log("Error: Mocha support is limited to remote (Saucelabs) Appium at this time. Please specify an Appium device with --browser");
-  process.exit(1);
 }
 
 //
@@ -212,7 +208,7 @@ var startSuite = function () {
 };
 
 browsers.initialize(isSauce)
-  .then(browserOptions.detectFromCLI.bind(this, margs.argv, isSauce))
+  .then(browserOptions.detectFromCLI.bind(this, margs.argv, isSauce, isNodeBased))
   .then(function (_selectedBrowsers) {
     selectedBrowsers = _selectedBrowsers;
     if (_selectedBrowsers.length === 0) {

--- a/magellan.json
+++ b/magellan.json
@@ -1,0 +1,7 @@
+{
+  "mocha_tests": ["./test"],
+  "framework": "vanilla-mocha",
+  "no_tunnels": true,
+  "sauce": false,
+  "max_workers": 7
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test": "./node_modules/.bin/mocha test"
+    "test": "./bin/magellan"
   },
   "dependencies": {
     "acorn": "^2.1.0",

--- a/src/detect-browsers.js
+++ b/src/detect-browsers.js
@@ -24,7 +24,7 @@ module.exports = {
 
   // Return a promise that we'll resolve with a list of browsers selected
   // by the user from command line arguments
-  detectFromCLI: function (argv, sauceEnabled) {
+  detectFromCLI: function (argv, sauceEnabled, isNodeBased) {
     var deferred = Q.defer();
     var browsers;
 
@@ -121,8 +121,13 @@ module.exports = {
         if (sauceEnabled) {
           browsers = [];
         } else {
-          var phantomBrowser = Browser("phantomjs", argv.resolution, argv.orientation);
-          browsers = [phantomBrowser];
+          var fallbackBrowser;
+          if (isNodeBased) {
+            fallbackBrowser = Browser("nodejs", argv.resolution, argv.orientation);
+          } else {
+            fallbackBrowser = Browser("phantomjs", argv.resolution, argv.orientation);
+          }
+          browsers = [fallbackBrowser];
         }
       }
     }

--- a/src/interop/lib/amend_node_config.js
+++ b/src/interop/lib/amend_node_config.js
@@ -1,0 +1,22 @@
+var _ = require("lodash");
+
+module.exports = function (env, nodeConfigAdditions) {
+  var nodeConfig = env.NODE_CONFIG;
+
+  if (typeof nodeConfig === "string") {
+    try {
+      nodeConfig = JSON.parse(nodeConfig);
+    } catch (e) {
+      // bad node config. Just start a new one
+      nodeConfig = {};
+    }
+  }
+
+  if (nodeConfig && typeof nodeConfig === "object") {
+    // already an object {}
+  } else {
+    nodeConfig = {};
+  }
+
+  return _.extend(nodeConfig, nodeConfigAdditions);
+};

--- a/src/interop/lib/get_mocha_tests.js
+++ b/src/interop/lib/get_mocha_tests.js
@@ -4,9 +4,9 @@ var walk = require("acorn/dist/walk");
 var path = require("path");
 var fs = require("fs");
 
-var settings = require("../../settings");
+var mochaSettings = require("./mocha_settings");
 
-var sourceFolders = settings.mochaTestFolders;
+var sourceFolders = mochaSettings.mochaTestFolders;
 
 var Path = function (path, filename, id) {
   this.path = path;

--- a/src/interop/lib/mocha_settings.js
+++ b/src/interop/lib/mocha_settings.js
@@ -4,8 +4,5 @@ var argv = margs.argv;
 module.exports = {
   mochaOpts: argv.mocha_opts, // --mocha_opts opts_file
 
-  mochaTestFolders: argv.mocha_tests, // --mocha_tests location (or array in magellan.json)
-
-  // TODO: deprecate and make this the responsibility of the test suite itself
-  appiumApplicationLocation: argv.appium_application_location
+  mochaTestFolders: argv.mocha_tests // --mocha_tests location (or array in magellan.json)
 };

--- a/src/interop/lib/mocha_settings.js
+++ b/src/interop/lib/mocha_settings.js
@@ -1,0 +1,11 @@
+var margs = require("../../margs");
+var argv = margs.argv;
+
+module.exports = {
+  mochaOpts: argv.mocha_opts, // --mocha_opts opts_file
+
+  mochaTestFolders: argv.mocha_tests, // --mocha_tests location (or array in magellan.json)
+
+  // TODO: deprecate and make this the responsibility of the test suite itself
+  appiumApplicationLocation: argv.appium_application_location
+};

--- a/src/interop/rowdy-mocha/get_tests.js
+++ b/src/interop/rowdy-mocha/get_tests.js
@@ -1,0 +1,1 @@
+module.exports = require("../lib/get_mocha_tests");

--- a/src/interop/rowdy-mocha/test_run.js
+++ b/src/interop/rowdy-mocha/test_run.js
@@ -46,26 +46,9 @@ RowdyMochaTestRun.prototype.getEnvironment = function (env) {
     FUNC_PORT: this.mockingPort
   };
 
-  var nodeConfig = env.NODE_CONFIG;
+  var nodeConfig = require("../lib/amend_node_config")(env, mockingSettings);
 
-  if (typeof nodeConfig === "string") {
-    try {
-      nodeConfig = JSON.parse(env.NODE_CONFIG);
-    } catch (e) {
-      // bad node config. Just start a new one
-      nodeConfig = {};
-    }
-  }
-
-  if (nodeConfig && typeof nodeConfig === "object") {
-    // already an object {}
-  } else {
-    nodeConfig = {};
-  }
-
-  nodeConfig = _.extend(nodeConfig, mockingSettings);
-
-  return _.extend({
+  return _.extend(env, mockingSettings, {
     // Example values for rowdy:
     // "local.phantomjs"
     // "sauceLabs.safari_7_OS_X_10_9_Desktop"
@@ -79,7 +62,7 @@ RowdyMochaTestRun.prototype.getEnvironment = function (env) {
         "port": this.seleniumPort
       }
     })
-  }, mockingSettings, env);
+  });
 };
 
 RowdyMochaTestRun.prototype.getArguments = function () {

--- a/src/interop/rowdy-mocha/test_run.js
+++ b/src/interop/rowdy-mocha/test_run.js
@@ -1,0 +1,110 @@
+/*
+  Provide
+*/
+var util = require("util");
+var _ = require("lodash");
+var BaseTestrun = require("../../test_run");
+
+var settings = require("../../settings");
+var mochaSettings = require("../lib/mocha_settings");
+
+var RowdyMochaTestRun = function (options) {
+  BaseTestrun.call(this, options);
+
+  if (options.sauceBrowserSettings) {
+    this.rowdyBrowser = "sauceLabs." + options.sauceBrowserSettings.id;
+  } else {
+    this.rowdyBrowser = "local." + this.test.browser.browserId;
+  }
+
+  // needed if local testing
+  this.seleniumPort = this.worker.portOffset + 1;
+
+  // needed if you're using a mock
+  this.mockingPort = this.worker.portOffset;
+};
+
+util.inherits(RowdyMochaTestRun, BaseTestrun);
+
+// return the command line path to the test framework binary
+RowdyMochaTestRun.prototype.getCommand = function () {
+  return "./node_modules/.bin/mocha";
+};
+
+// return the environment
+RowdyMochaTestRun.prototype.getEnvironment = function (env) {
+  /*
+    Several ways to tell a mocha client where to find its mocking port:
+
+    NODE_CONFIG object ( i.e http://npmjs.org/packages/config )
+    process.env.MOCKING_PORT
+    process.env.FUNC_PORT
+    --mocking_port=NNN (process.argv)
+  */
+  var mockingSettings = {
+    MOCKING_PORT: this.mockingPort,
+    FUNC_PORT: this.mockingPort
+  };
+
+  var nodeConfig = env.NODE_CONFIG;
+
+  if (typeof nodeConfig === "string") {
+    try {
+      nodeConfig = JSON.parse(env.NODE_CONFIG);
+    } catch (e) {
+      // bad node config. Just start a new one
+      nodeConfig = {};
+    }
+  }
+
+  if (nodeConfig && typeof nodeConfig === "object") {
+    // already an object {}
+  } else {
+    nodeConfig = {};
+  }
+
+  nodeConfig = _.extend(nodeConfig, mockingSettings);
+
+  return _.extend({
+    // Example values for rowdy:
+    // "local.phantomjs"
+    // "sauceLabs.safari_7_OS_X_10_9_Desktop"
+    NODE_CONFIG: JSON.stringify(nodeConfig),
+    ROWDY_SETTINGS: this.rowdyBrowser,
+    ROWDY_OPTIONS: JSON.stringify({
+      "server": {
+        "port": this.seleniumPort
+      },
+      "client": {
+        "port": this.seleniumPort
+      }
+    })
+  }, mockingSettings, env);
+};
+
+RowdyMochaTestRun.prototype.getArguments = function () {
+  var grepString = this.path.toString();
+
+  var escapees = "\\^$[]+*.\"";
+  escapees.split("").forEach(function (ch) {
+    grepString = grepString.split(ch).join("\\" + ch);
+  });
+
+  var args = [
+    "--mocking_port=" + this.mockingPort,
+    "--worker=1",
+    this.path.filename
+  ];
+
+  if (mochaSettings.mochaOpts) {
+    args.push("--opts");
+    args.push(mochaSettings.mochaOpts);
+  }
+
+  args.push("-g");
+  args.push(grepString);
+
+  return args;
+};
+
+module.exports = RowdyMochaTestRun;

--- a/src/interop/vanilla-mocha/get_tests.js
+++ b/src/interop/vanilla-mocha/get_tests.js
@@ -1,0 +1,1 @@
+module.exports = require("../lib/get_mocha_tests");

--- a/src/interop/vanilla-mocha/test_run.js
+++ b/src/interop/vanilla-mocha/test_run.js
@@ -49,7 +49,7 @@ MochaTestRun.prototype.getEnvironment = function (env) {
 
 MochaTestRun.prototype.getArguments = function () {
   var grepString = this.path.toString();
-  var escapees = "\\^$[]*.\"";
+  var escapees = "\\^$[]+*.\"";
   escapees.split("").forEach(function (ch) {
     grepString = grepString.split(ch).join("\\" + ch);
   });

--- a/src/interop/vanilla-mocha/test_run.js
+++ b/src/interop/vanilla-mocha/test_run.js
@@ -34,17 +34,13 @@ MochaTestRun.prototype.getCommand = function () {
 
 // return the environment
 MochaTestRun.prototype.getEnvironment = function (env) {
-  var config = {
-    desiredCapabilities: this.sauceBrowserSettings,
-    appiumAppLocation: settings.appiumApplicationLocation,
-    sauceSettings: {
-      testServer: "http://" + process.env.SAUCE_USERNAME + ":" + process.env.SAUCE_ACCESS_KEY + "@ondemand.saucelabs.com:80/wd/hub"
-    }
-  };
+  var nodeConfig = require("../lib/amend_node_config")(env, {
+    desiredCapabilities: this.sauceBrowserSettings
+  });
 
-  return _.extend({
-    NODE_CONFIG: JSON.stringify(config)
-  }, env);
+  return _.extend(env, {
+    NODE_CONFIG: JSON.stringify(nodeConfig)
+  });
 };
 
 MochaTestRun.prototype.getArguments = function () {

--- a/src/settings.js
+++ b/src/settings.js
@@ -43,19 +43,11 @@ module.exports = {
 
   buildId: buildId,
 
-  //
-  //
-  // TODO: allow for framework setting via magellan.json
-  //
-  //
   framework: argv.framework || "magellan-nightwatch",
 
   // TODO: move this to interop
   // Default to a config location that is the same as the magellan-boilerplate
   nightwatchConfigFilePath: argv.nightwatch_config || (fs.existsSync("./nightwatch.json") ? "./nightwatch.json" : "./conf/nightwatch.json"),
-
-  mochaTestFolders: argv.mocha_tests,
-  appiumApplicationLocation: argv.appium_application_location,
 
   customSauceBrowsers: argv.customSauceBrowsers || []
 };

--- a/src/settings.js
+++ b/src/settings.js
@@ -28,7 +28,7 @@ module.exports = {
   BASE_PORT_RANGE: parseInt(argv.base_port_range) || 2000,
   BASE_PORT_SPACING: parseInt(argv.base_port_spacing) || 3,
 
-  environment: process.env,
+  environment: env,
 
   debug: argv.debug,
 

--- a/src/test_filter.js
+++ b/src/test_filter.js
@@ -2,7 +2,8 @@ var path = require("path"),
   fs = require("fs"),
   _ = require("lodash"),
   acorn = require("acorn"),
-  walk = require("acorn/dist/walk");
+  walk = require("acorn/dist/walk"),
+  settings = require("./settings");
 
 var filterByTags = function(files, tags) {
   // Tidy up tag input. If we have a comma-delimited list, tokenize and clean it up
@@ -94,8 +95,17 @@ var PREDEFINED_FILTERS = {
     console.log("Using test filter: ", filename);
 
     return files.filter(function(f) {
-      if (path.resolve(f.trim()) === path.resolve(filename.trim())) {
-        return true;
+      //
+      // TODO: instead check if this is an instance of a Path object, not "mocha" substring check
+      //
+      if (settings.framework.indexOf("mocha") > -1) {
+        if (f.path === filename) {
+          return true;
+        }
+      } else {
+        if (path.resolve(f.trim()) === path.resolve(filename.trim())) {
+          return true;
+        }
       }
     });
   },


### PR DESCRIPTION
This PR includes
  - A shuffling of existing "vanilla" mocha support (for our existing convention-based appium support) to `mocha-vanilla`
  - A new `mocha-rowdy` integration
  - Fixes to by-test (`--test`) filtering for mocha-based test suites.
  - node.js suite support (magellan can run its own tests using mocha-vanilla)