### PR TITLE
Tunnel Support for Mocha / Changes to Tunnel Defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,9 @@ export SAUCE_TUNNEL_ID="xxxxxxxxx"
 SauceLabs Tunnelling Support (Sauce Connect)
 ============================================
 
-**NOTE**: By default, Magellan assumes that tests run within a secure network and that a tunnel is required from SauceLabs to your test machine. If you don't need this option and want faster `--sauce` initialization, you can use `--no_tunnels` at runtime to skip the tunnel construction process.
+**NOTE**: By default, Magellan assumes that tests run on an open network visible to SauceLabs. 
+
+If your tests are running in a closed CI environment not visible to the Internet, a tunnel is required from SauceLabs to your test machine (when using `--sauce` mode). To activate tunnel creation, use `--create_tunnels`. Magellan will create a unique tunnel for each worker.
 
 Display Resolution and Orientation Support (SauceLabs Browsers)
 ===============================================================

--- a/src/cli_help.js
+++ b/src/cli_help.js
@@ -33,7 +33,7 @@ module.exports = {
     console.log("  --browser=browsername        Run tests in chrome, firefox, etc (default: phantomjs).");
     console.log("  --browsers=b1,b2,..          Run multiple browsers in parallel.");
     console.log("  --browsers=all               Run all available browsers (sauce only).");
-    console.log("  --no_tunnels                 Don't use tunnels in sauce mode (for use with --sauce only)");
+    console.log("  --create_tunnels             Create secure tunnels in sauce mode (for use with --sauce only)");
     console.log("  --profile=p1,p2,..           Specify lists of browsers to use defined in profiles in magellan.json config.")
     console.log("");
     console.log("  +------------------------------------------+-----------+-------------------+");

--- a/src/interop/rowdy-mocha/test_run.js
+++ b/src/interop/rowdy-mocha/test_run.js
@@ -17,6 +17,10 @@ var RowdyMochaTestRun = function (options) {
     this.rowdyBrowser = "local." + this.test.browser.browserId;
   }
 
+  if (options.sauceSettings && options.sauceSettings.useTunnels) {
+    this.tunnelId = this.worker.tunnelId;
+  }
+
   // needed if local testing
   this.seleniumPort = this.worker.portOffset + 1;
 
@@ -52,6 +56,7 @@ RowdyMochaTestRun.prototype.getEnvironment = function (env) {
     // Example values for rowdy:
     // "local.phantomjs"
     // "sauceLabs.safari_7_OS_X_10_9_Desktop"
+    SAUCE_CONNECT_TUNNEL_ID: this.tunnelId,
     NODE_CONFIG: JSON.stringify(nodeConfig),
     ROWDY_SETTINGS: this.rowdyBrowser,
     ROWDY_OPTIONS: JSON.stringify({

--- a/src/interop/vanilla-mocha/test_run.js
+++ b/src/interop/vanilla-mocha/test_run.js
@@ -18,6 +18,10 @@ var MochaTestRun = function (options) {
   delete this.sauceBrowserSettings.resolutions;
   delete this.sauceBrowserSettings.id;
 
+  if (options.sauceSettings && options.sauceSettings.useTunnels) {
+    this.sauceBrowserSettings.tunnelId = this.worker.tunnelId;
+  }
+
   // needed if local testing
   this.seleniumPort = this.worker.portOffset + 1;
 

--- a/src/sauce/settings.js
+++ b/src/sauce/settings.js
@@ -13,7 +13,7 @@ var config = {
 
   // optional:
   tunnelTimeout:        process.env.SAUCE_TUNNEL_CLOSE_TIMEOUT,
-  useTunnels:           !argv.no_tunnels
+  useTunnels:           !!argv.create_tunnels
 };
 
 var parameterWarnings = {


### PR DESCRIPTION
PR notes:
  - `--create_tunnels` is now required to use sauce connect. Magellan will otherwise skip tunnel creation. 
  - The option previously known as `--no_tunnels` is now default
