### PR TITLE
Tunnel sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Features
     - [Admiral](https://github.com/TestArmada/admiral) reporting support.
     - Plays well with CI (Jenkins, etc).
     - SauceLabs Remote Browser and Device Support:
-      - Optional tunnel management.
+      - Optional Sauce Connect tunnel management (`--create_tunnels`).
       - Create lists of browser tiers or browser testing groups with browser profiles (eg: tier1 browsers, tier2 browsers, mobile browsers, vintage IE versions, etc).
       - Manage not just browsers, but also devices for native application testing (iOS and Android)
 
@@ -303,7 +303,11 @@ export SAUCE_ACCESS_KEY='xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 
 # SauceConnect version for download
 export SAUCE_CONNECT_VERSION=4.3.10
+```
 
+A Sauce Connect tunnel prefix must be set for tunnel management to work when using `--create_tunnels` (see more on this below).
+
+```
 # Tunnel id prefix, Example: "my_tunnel", "qa_tunnel", etc
 export SAUCE_TUNNEL_ID="xxxxxxxxx"
 ```
@@ -335,7 +339,13 @@ SauceLabs Tunnelling Support (Sauce Connect)
 
 **NOTE**: By default, Magellan assumes that tests run on an open network visible to SauceLabs. 
 
-If your tests are running in a closed CI environment not visible to the Internet, a tunnel is required from SauceLabs to your test machine (when using `--sauce` mode). To activate tunnel creation, use `--create_tunnels`. Magellan will create a unique tunnel for each worker.
+If your tests are running in a closed CI environment not visible to the Internet, a tunnel is required from SauceLabs to your test machine (when using `--sauce` mode). To activate tunnel creation, use `--create_tunnels`. Magellan will create a tunnel for the test run. If you want to distribute your work load across more than one tunnel, specify the `--max_tunnels=N` option, like so:
+
+```console
+$ magellan --sauce --browser=chrome_42_Windows_2012_R2_Desktop --create_tunnels --max_tunnels=4 --max_workers=16
+```
+
+In the above example, 4 tunnels will be distributed amongst 16 workers.
 
 Display Resolution and Orientation Support (SauceLabs Browsers)
 ===============================================================

--- a/src/sauce/settings.js
+++ b/src/sauce/settings.js
@@ -13,7 +13,8 @@ var config = {
 
   // optional:
   tunnelTimeout:        process.env.SAUCE_TUNNEL_CLOSE_TIMEOUT,
-  useTunnels:           !!argv.create_tunnels
+  useTunnels:           !!argv.create_tunnels,
+  maxTunnels:           argv.num_tunnels
 };
 
 var parameterWarnings = {

--- a/src/sauce/settings.js
+++ b/src/sauce/settings.js
@@ -14,7 +14,7 @@ var config = {
   // optional:
   tunnelTimeout:        process.env.SAUCE_TUNNEL_CLOSE_TIMEOUT,
   useTunnels:           !!argv.create_tunnels,
-  maxTunnels:           argv.num_tunnels
+  maxTunnels:           argv.num_tunnels || 1
 };
 
 var parameterWarnings = {

--- a/src/sauce/worker_allocator.js
+++ b/src/sauce/worker_allocator.js
@@ -14,7 +14,7 @@ var SauceWorkerAllocator = function (_MAX_WORKERS) {
   this.tunnels = [];
   this.tunnelErrors = [];
   this.MAX_WORKERS = _MAX_WORKERS;
-  this.maxTunnels = Math.min(sauceSettings.maxTunnels || _MAX_WORKERS, _MAX_WORKERS);
+  this.maxTunnels = sauceSettings.maxTunnels;
   this.tunnelPrefix = Math.round(Math.random() * 99999).toString(16);
 };
 

--- a/src/sauce/worker_allocator.js
+++ b/src/sauce/worker_allocator.js
@@ -14,6 +14,8 @@ var SauceWorkerAllocator = function (_MAX_WORKERS) {
   this.tunnels = [];
   this.tunnelErrors = [];
   this.MAX_WORKERS = _MAX_WORKERS;
+  this.maxTunnels = Math.min(sauceSettings.maxTunnels || _MAX_WORKERS, _MAX_WORKERS);
+  this.tunnelPrefix = Math.round(Math.random() * 99999).toString(16);
 };
 
 util.inherits(SauceWorkerAllocator, BaseWorkerAllocator);
@@ -32,11 +34,9 @@ SauceWorkerAllocator.prototype.initialize = function (callback) {
           if (err) {
             callback(new Error("Cannot initialize worker allocator: " + err.toString()));
           } else {
-            // NOTE: If we only managed to fewer tunnels than we requested,
-            // we need to reduce the number of workers.
-            if (this.tunnels.length !== this.MAX_WORKERS) {
-              this.initializeWorkers(this.tunnels.length);
-            }
+            // NOTE: We wait until we know how many tunnels we actually got before
+            // we assign tunnel ids to workers.
+            this.assignTunnelsToWorkers(this.tunnels.length);
             callback();
           }
         }.bind(this));
@@ -45,15 +45,18 @@ SauceWorkerAllocator.prototype.initialize = function (callback) {
   }
 };
 
-SauceWorkerAllocator.prototype.initializeWorkers = function (numWorkers) {
-  BaseWorkerAllocator.prototype.initializeWorkers.call(this, numWorkers);
+SauceWorkerAllocator.prototype.assignTunnelsToWorkers = function (numOpenedTunnels) {
+  var self = this;
 
-  if (sauceSettings.useTunnels) {
-    // Assign a tunnel id for each worker.
-    this.workers.forEach(function (worker){
-      worker.tunnelId = sauceSettings.tunnelId + "_" + (worker.index) + "_" + Math.round(Math.random() * 99999).toString(16);
-    });
-  }
+  // Assign a tunnel id for each worker.
+  this.workers.forEach(function (worker, i) {
+    worker.tunnelId = self.getTunnelId(i % numOpenedTunnels);
+    console.log("Assigning worker " + worker.index + " to tunnel " + worker.tunnelId)
+  });
+};
+
+SauceWorkerAllocator.prototype.getTunnelId = function (tunnelIndex) {
+  return sauceSettings.tunnelId + "_" + this.tunnelPrefix + "_" + tunnelIndex;
 };
 
 SauceWorkerAllocator.prototype.teardown = function (callback) {
@@ -75,17 +78,17 @@ SauceWorkerAllocator.prototype.openTunnels = function(callback) {
       self.tunnels.push(tunnelInfo);
     }
 
-    if (self.tunnels.length === self.MAX_WORKERS) {
+    if (self.tunnels.length === self.maxTunnels) {
       console.log("All tunnels open!  Continuing...");
       callback();
-    } else if (self.tunnels.length > 0 && (self.tunnels.length + self.tunnelErrors.length === self.MAX_WORKERS)) {
+    } else if (self.tunnels.length > 0 && (self.tunnels.length + self.tunnelErrors.length === self.maxTunnels)) {
       // We've accumulated some tunnels and some errors. Continue with a limited number of workers?
-      console.log("Opened only " + self.tunnels.length + " tunnels out of " + self.MAX_WORKERS + " requested (due to errors).");
+      console.log("Opened only " + self.tunnels.length + " tunnels out of " + self.maxTunnels + " requested (due to errors).");
       console.log("Continuing with a reduced number of workers (" + self.tunnels.length + ").")
       callback();
-    } else if (self.tunnelErrors.length === self.MAX_WORKERS) {
+    } else if (self.tunnelErrors.length === self.maxTunnels) {
       // We've tried to open N tunnels but instead got N errors.
-      callback(new Error("\nCould not open any sauce tunnels (attempted to open " + self.MAX_WORKERS + " total tunnels): \n" + 
+      callback(new Error("\nCould not open any sauce tunnels (attempted to open " + self.maxTunnels + " total tunnels): \n" + 
           self.tunnelErrors.map(function(err) {
             return err.toString();
           }).join("\n") + "\nPlease check that there are no sauce-connect-launcher (sc) processes running."
@@ -94,33 +97,32 @@ SauceWorkerAllocator.prototype.openTunnels = function(callback) {
       if (err) {
         console.log("Failed to open a tunnel, number of failed tunnels: " + self.tunnelErrors.length);
       }
-      console.log(self.tunnels.length + " of " + self.MAX_WORKERS + " tunnels open.  Waiting...");
+      console.log(self.tunnels.length + " of " + self.maxTunnels + " tunnels open.  Waiting...");
     }
   };
 
-  var openTunnel = function(tunnelNum) {
+  var openTunnel = function(tunnelIndex) {
 
-    console.log("Opening tunnel " + tunnelNum + " of " + self.MAX_WORKERS);
+    var tunnelId = self.getTunnelId(tunnelIndex);
+    console.log("Opening tunnel " + tunnelIndex + " of " + self.maxTunnels + " [id = " + tunnelId + "]");
 
     var options = {
-      // NOTE: Workers are indexed from 1 for readability purposes, but worker 1 is at index 0.
-      tunnelId: self.workers[tunnelNum - 1].tunnelId,
+      tunnelId: tunnelId,
       username: sauceSettings.username,
       accessKey: sauceSettings.accessKey,
-      seleniumPort: BASE_SELENIUM_PORT_OFFSET + tunnelNum,
+      seleniumPort: BASE_SELENIUM_PORT_OFFSET + (tunnelIndex + 1),
       callback: tunnelOpened
     };
 
     tunnel.open(options);
   };
 
-  _.times(this.MAX_WORKERS, function(n) {
+  _.times(this.maxTunnels, function (n) {
     // worker numbers are 1-indexed
-    n = n + 1;
     console.log("Waiting " + n + " sec to open tunnel #" + n);
     _.delay(function() {
       openTunnel(n);
-    }, n * 2000);
+    }, n * 1000);
   });
 
 };
@@ -165,6 +167,7 @@ SauceWorkerAllocator.prototype.cleanupTunnels = function(callback) {
   // are still active at this point, we need to forcefully kill them so that we're not
   // leaving the build environment in a polluted state.
 
+  // NOTE: this may not be Windows compatible
   var cmd = "pkill -9 -f " + sauceSettings.tunnelId;
 
   console.log("Cleaning up any remaining sauce connect processes with: " + cmd);


### PR DESCRIPTION
  - default at 1 tunnels instead of `max_workers`
  - introduce `--max_tunnels` to allow an arbitrary number of tunnels to be used
  - [x] document
  - [x] test on large mocked suites (with huge codebases, images, etc)

![image](https://cloud.githubusercontent.com/assets/12995/9535433/1e614e78-4cd6-11e5-8c2d-26fcbc14ed29.png)

/cc @geekdave 
