### PR TITLE
Add undocumented support for unlisted device addendums

### DIFF
--- a/bin/magellan
+++ b/bin/magellan
@@ -41,6 +41,9 @@ if (margs.argv.help) {
 
 if (margs.argv.list_browsers) {
   browsers.initialize(true).then(function () {
+    if (margs.argv.device_additions) {
+      browsers.addDevicesFromFile(margs.argv.device_additions);
+    }
     browsers.listBrowsers();
     process.exit(0);
   }).catch(function (err) {
@@ -208,6 +211,11 @@ var startSuite = function () {
 };
 
 browsers.initialize(isSauce)
+  .then(function () {
+    if (margs.argv.device_additions) {
+      browsers.addDevicesFromFile(margs.argv.device_additions);
+    }
+  })
   .then(browserOptions.detectFromCLI.bind(this, margs.argv, isSauce, isNodeBased))
   .then(function (_selectedBrowsers) {
     selectedBrowsers = _selectedBrowsers;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cli-color": "^0.3.2",
     "cli-table": "^0.3.1",
     "glob": "^5.0.5",
-    "guacamole": "1.1.1",
+    "guacamole": "1.1.4",
     "lodash": "^3.10.0",
     "node-slackr": "0.0.4",
     "once": "^1.3.1",

--- a/src/sauce/browsers.js
+++ b/src/sauce/browsers.js
@@ -76,6 +76,10 @@ module.exports = {
     return result;
   },
 
+  addDevicesFromFile: function (filePath) {
+    SauceBrowsers.addNormalizedBrowsersFromFile(filePath);
+  },
+
   initialize: function (fetchSauceBrowsers) {
     if (fetchSauceBrowsers) {
       return SauceBrowsers.initialize();


### PR DESCRIPTION
This PR adds an undocumented beta feature for adding unlisted devices. This is not intended to be `desiredCapabilities` "override" feature, and is subject to removal.