### PR TITLE
Hosted Profiles Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,37 @@ $ magellan --profile=my_profile_1
 $ magellan --profile=tier_1_browsers,tier_2_browsers
 ```
 
+Hosted Browser Profiles
+=======================
+
+If you're using profiles to reflect browser tiers in a large organization, you may wish to centralize your profiles on a web server somewhere and have `magellan` load them remotely. To do this, specify a profile URL to source profiles from, and the profile you want to use after a `#` (hash):
+
+```console
+$ magellan --profile=http://example.com/testing/browser_profiles.json#tier2
+```
+
+Multiple profiles can be specified the same way, comma delimited:
+
+```console
+$ magellan --profile=http://example.com/testing/browser_profiles.json#tier1,tier2
+```
+
+
+Where `browser_profiles.json` should have a structure similar to placing `profiles{}` in `magellan.json`:
+
+```json
+{
+  "profiles": {
+    "tier_2": [
+      { "browser": "safari_7_OS_X_10_9_Desktop" },
+      { "browser": "IE_8_Windows_2008_Desktop" },
+      { "browser": "IE_9_Windows_2008_Desktop" },
+      { "browser": "IE_10_Windows_2008_Desktop" }
+    ]
+  }
+```
+
+
 Setting Up Setup and Teardown Tasks for CI
 ==========================================
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "qs": "2.2.4",
     "request": "^2.55.0",
     "sauce-connect-launcher": "0.11.0",
+    "sync-request": "^2.0.1",
     "slugify": "^0.1.1",
     "yargs": "1.3.2"
   },

--- a/src/cli_help.js
+++ b/src/cli_help.js
@@ -35,6 +35,7 @@ module.exports = {
     console.log("  --browsers=all               Run all available browsers (sauce only).");
     console.log("  --create_tunnels             Create secure tunnels in sauce mode (for use with --sauce only)");
     console.log("  --profile=p1,p2,..           Specify lists of browsers to use defined in profiles in magellan.json config.")
+    console.log("  --profile=http://abc/p#p1,p2 Use profiles p1 and p2 hosted at JSON file http://abc/p (see README for details).")
     console.log("");
     console.log("  +------------------------------------------+-----------+-------------------+");
     console.log("  | Workflow / Output Examples               | # workers | output style      |");

--- a/src/detect-browsers.js
+++ b/src/detect-browsers.js
@@ -1,5 +1,7 @@
 var sauceBrowsers = require("./sauce/browsers.js");
 var Q = require("q");
+var hostedProfiles = require("./hosted_profiles");
+var _ = require("lodash");
 
 var Browser = function (id, resolution, orientation) {
   var result = {
@@ -32,6 +34,20 @@ module.exports = {
     // a browser is set ia CLI, we assume details from the stored profile 
     // and override with anything else explicitly set.
     if (argv.profile) {
+
+      if (argv.profile.indexOf("http:") > -1 || argv.profile.indexOf("https:") > -1) {
+        // We fetch profiles from an URL if it starts with http: or https:
+        // We assume it will have a #fragment to identify a given desired profile.
+        // Note: The hosted profiles are merged on top of any local profiles.
+        var fetchedProfiles = hostedProfiles.getProfilesAtURL(argv.profile.split("#")[0]);
+        if (fetchedProfiles && fetchedProfiles.profiles) {
+          argv.profiles = _.extend({}, argv.profiles, fetchedProfiles.profiles);
+
+          console.log("Loaded hosted profiles from " + argv.profile.split("#")[0]);
+        }
+
+        argv.profile = hostedProfiles.getProfileNameFromURL(argv.profile);
+      }
 
       console.log("Requested profile(s): ", argv.profile);
 

--- a/src/hosted_profiles.js
+++ b/src/hosted_profiles.js
@@ -1,0 +1,38 @@
+var syncRequest = require("sync-request");
+var URL = require("url");
+
+module.exports = {
+
+  // Return a profile name from an URL if one is referenced with a #fragment.
+  // If not, just return nothing. Silently eat errors if there is no fragment
+  // or if the URL isn't valid.
+  getProfileNameFromURL: function (url) {
+    try {
+      url = URL.parse(url);
+    } catch (e) {
+    }
+    if (url && url.hash) {
+      return url.hash.split("#")[1];
+    }
+  },
+
+  getProfilesAtURL: function (url) {
+    var res = syncRequest("GET", url);
+    var data;
+
+    try {
+      data = JSON.parse(res.getBody("utf8"));
+    } catch (e) {
+      throw new Error("Could not fetch profiles from " + url);
+    }
+
+    if (data && !data.profiles) {
+      throw new Error("Profiles supplied at " + url + " are malformed.");
+    }
+
+    // return an object that can be used for extending and which 
+    // is not polluted with any other properties.
+    return { profiles: data.profiles };
+  },
+
+};


### PR DESCRIPTION
Solves #30

This PR implements hosted profile support. Profiles can now be specified with an URL and a hash, like so:
```console
$ ./bin/magellan --profile=https://gist.githubusercontent.com/Maciek416/13c6e111d5814f22f1d6/raw/005387ad975b407bbed83a0dc44f1eab29e5ec29/profile.json#tier2
Loaded magellan configuration from: magellan.json
Sauce configuration OK
Loaded hosted profiles from https://gist.githubusercontent.com/Maciek416/13c6e111d5814f22f1d6/raw/005387ad975b407bbed83a0dc44f1eab29e5ec29/profile.json
Requested profile(s):  tier2

Running 28 tests with 7 workers with safari_7_OS_X_10_9_Desktop, IE_8_Windows_2008_Desktop, IE_9_Windows_2008_Desktop, IE_10_Windows_2008_Desktop
```