### PR TITLE
Fix custom reporters -- bad path

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,3 @@
 module.exports = {
-  Reporter: require("./reporter/reporter")
+  Reporter: require("./reporters/reporter")
 };


### PR DESCRIPTION
A bad path has been inhibiting custom reporters from working. Also, `README` had an incorrect example for this feature (already updated in master).