### PR TITLE
Add support for a locks server for sauce VM allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Features
       - Optional Sauce Connect tunnel management (`--create_tunnels`).
       - Create lists of browser tiers or browser testing groups with browser profiles (eg: tier1 browsers, tier2 browsers, mobile browsers, vintage IE versions, etc).
       - Manage not just browsers, but also devices for native application testing (iOS and Android)
+    - Can talk to a [locks service](https://github.com/TestArmada/locks) to control saucelabs virtual machine usage (beta).
 
 Test Framework Compatibility
 ============================
@@ -346,6 +347,20 @@ $ magellan --sauce --browser=chrome_42_Windows_2012_R2_Desktop --create_tunnels 
 ```
 
 In the above example, 4 tunnels will be distributed amongst 16 workers.
+
+SauceLabs VM Traffic Control (`locks`)
+======================================
+
+To specify a `locks` server, set the environment variable `LOCKS_SERVER_URL`:
+
+```
+export LOCKS_SERVER_URL=http://locks.server.example:4765
+```
+
+or use the `--locks_server` option:
+```
+$ magellan --locks_server=http://locks.server.example:4765 --sauce --browser=chrome_42_Windows_2012_R2_Desktop --create_tunnels --max_tunnels=4 --max_workers=16
+```
 
 Display Resolution and Orientation Support (SauceLabs Browsers)
 ===============================================================

--- a/src/sauce/settings.js
+++ b/src/sauce/settings.js
@@ -16,7 +16,7 @@ var config = {
   useTunnels:           !!argv.create_tunnels,
   maxTunnels:           argv.num_tunnels || 1,
 
-  locksServerURL:             argv.locks_server || "http://0.0.0.0:3000/claim"
+  locksServerURL:             argv.locks_server || "http://0.0.0.0:3000/"
 };
 
 var parameterWarnings = {

--- a/src/sauce/settings.js
+++ b/src/sauce/settings.js
@@ -16,7 +16,7 @@ var config = {
   useTunnels:           !!argv.create_tunnels,
   maxTunnels:           argv.num_tunnels || 1,
 
-  locksServerURL:             argv.locks_server || "http://0.0.0.0:3000/"
+  locksServerURL:       argv.locks_server || process.env.LOCKS_SERVER_URL
 };
 
 var parameterWarnings = {

--- a/src/sauce/settings.js
+++ b/src/sauce/settings.js
@@ -14,7 +14,9 @@ var config = {
   // optional:
   tunnelTimeout:        process.env.SAUCE_TUNNEL_CLOSE_TIMEOUT,
   useTunnels:           !!argv.create_tunnels,
-  maxTunnels:           argv.num_tunnels || 1
+  maxTunnels:           argv.num_tunnels || 1,
+
+  locksServerURL:             argv.locks_server || "http://0.0.0.0:3000/claim"
 };
 
 var parameterWarnings = {

--- a/src/sauce/worker_allocator.js
+++ b/src/sauce/worker_allocator.js
@@ -48,21 +48,23 @@ SauceWorkerAllocator.prototype.initialize = function (callback) {
 };
 
 SauceWorkerAllocator.prototype.release = function (worker) {
+  var self = this;
   if (sauceSettings.locksServerURL) {
-    // notify `locks` server we're done with this VM
-    request.post({
-      url: sauceSettings.locksServerURL + "/release",
-      form: {
+    request({
+      method: "POST",
+      json: true,
+      body: {
         token: worker.token
-      }
+      },
+      url: sauceSettings.locksServerURL + "/release"
     }, function (error, response, body) {
       // TODO: decide whether we care about an error at this stage. We're releasing
       // this worker whether the remote release is successful or not, since it will
       // eventually be timed out by the locks server.
-      BaseWorkerAllocator.prototype.release.call(worker);
+      BaseWorkerAllocator.prototype.release.call(self, worker);
     });
   } else {
-    BaseWorkerAllocator.prototype.release.call(worker);
+    BaseWorkerAllocator.prototype.release.call(self, worker);
   }
 };
 
@@ -105,7 +107,7 @@ SauceWorkerAllocator.prototype.get = function (callback) {
             return callback(new Error("Result from locks server is invalid or empty: '" + result + "'" ));
           }
         } catch (e) {
-          return callback(new Error("Could not parse result from locks server: " + e));
+          return callback(new Error("Could not parse result from locks server: " + e + "\n\nbody of response:" + body));
         }
       });
     };

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -373,20 +373,24 @@ TestRunner.prototype = {
 
     // do not report test starts if we've bailed.
     if (!this.hasBailed) {
+      var msg = [];
+
+      msg.push("-->");
+      msg.push((this.serial ? "Serial mode" : "Worker " + worker.index) + ",");
+
       if (this.sauceSettings && worker.tunnelId) {
-        var tunnelId = worker.tunnelId;
-        if (this.serial) {
-          console.log("--> Serial mode, tunnel id: " + tunnelId + ", mock port:" + worker.portOffset + ", running test: " + test.toString());
-        } else {
-          console.log("--> Worker " + worker.index + ", tunnel id: " + tunnelId + ", mock port:" + worker.portOffset + ", running test: " + test.toString());
-        }
-      } else {
-        if (this.serial) {
-          console.log("--> Serial mode, mock port: " + worker.portOffset + ", running test: " + test.toString());
-        } else {
-          console.log("--> Worker " + worker.index + ", mock port: " + worker.portOffset + ", running test: " + test.toString());
-        }
+        msg.push("tunnel id: " + worker.tunnelId + ",");
       }
+
+      msg.push("mock port:" + worker.portOffset + ",");
+
+      if (worker.token) {
+        msg.push("VM token:" + worker.token + ",");
+      }
+
+      msg.push("running test: " + test.toString());
+
+      console.log(msg.join(" "));
     }
 
     var testRun;

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -185,6 +185,7 @@ TestRunner.prototype = {
         // If the allocator could not give us a worker, pass
         // back a failed test result with the allocator's error.
         console.error("Worker allocator error: " + error);
+        console.error(error.stack);
 
         test.workerIndex = -1;
         test.error = undefined;

--- a/src/worker_allocator.js
+++ b/src/worker_allocator.js
@@ -145,8 +145,8 @@ Allocator.prototype = {
     }
   },
 
-  release: function (executor) {
-    executor.occupied = false;
+  release: function (worker) {
+    worker.occupied = false;
   }
 
 };


### PR DESCRIPTION
This PR adds support for the upcoming `locks` server.

TODO:

  - [x] Add support for notifying `locks` of released claim tokens.
  - [x] Clean up visual output.
  - [x] Documentation for setup.