### PR TITLE
Bail when found tests array is empty

### DIFF
--- a/bin/magellan
+++ b/bin/magellan
@@ -140,7 +140,7 @@ if (settings.aggregateScreenshots) {
 //
 var tests = getTests(testFilters.detectFromCLI(margs.argv));
 
-if (!tests || !tests.length) {
+if (_.isEmpty(tests)) {
   console.log("Error: no tests found");
   process.exit(1);
 }

--- a/bin/magellan
+++ b/bin/magellan
@@ -140,7 +140,7 @@ if (settings.aggregateScreenshots) {
 //
 var tests = getTests(testFilters.detectFromCLI(margs.argv));
 
-if (!tests) {
+if (!tests || !tests.length) {
   console.log("Error: no tests found");
   process.exit(1);
 }


### PR DESCRIPTION
When using a test file with a `describe` block but no `it` statements the runner continues. This checks the length of the returned `tests` array in addition to its presence.