### PR TITLE
Add CLI option for temp directory

### DIFF
--- a/src/cli_help.js
+++ b/src/cli_help.js
@@ -21,6 +21,7 @@ module.exports = {
     console.log(" Configuration:");
     console.log("  --config=config-path         Specify Magellan configuration location.");
     console.log("  --nightwatch_config=path     Specify nightwatch.json location (magellan-nightwatch)");
+    console.log("  --temp_dir=path              Specify temporary file directory for Magellan (default: temp/).");
     console.log("");
     console.log(" Reporting and CI Integration:");
     console.log("  --aggregate_screenshots      Activate harvesting of screenshots for uploading to a screenshot service.");

--- a/src/settings.js
+++ b/src/settings.js
@@ -9,7 +9,7 @@ var buildId = argv.external_build_id || "magellan-" + Math.round(Math.random() *
 
 // Create a temporary directory for temporary child build assets like configuration, screenshots, etc.
 var mkdirSync = require("./mkdir_sync");
-var TEMP_DIR = "./temp";
+var TEMP_DIR = argv.temp_dir || "./temp";
 var path = require("path");
 mkdirSync(path.resolve(TEMP_DIR));
 


### PR DESCRIPTION
Sometimes, you want to use the same temp directory for multiple build processes in your project.

Usage: e.g.

`bin/magellan --temp_dir=build`