### PR TITLE
Add support for getting tests recursively starting at a root folder.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "async": "^0.9.0",
     "cli-color": "^0.3.2",
     "cli-table": "^0.3.1",
+    "fs-readdir-recursive": "^1.0.0",
     "glob": "^5.0.5",
     "guacamole": "1.1.4",
     "lodash": "^3.10.0",
@@ -44,8 +45,8 @@
     "qs": "2.2.4",
     "request": "^2.55.0",
     "sauce-connect-launcher": "0.11.0",
-    "sync-request": "^2.0.1",
     "slugify": "^0.1.1",
+    "sync-request": "^2.0.1",
     "yargs": "1.3.2"
   },
   "engineStrict": true,

--- a/src/interop/lib/get_mocha_tests.js
+++ b/src/interop/lib/get_mocha_tests.js
@@ -3,6 +3,7 @@ var acorn = require("acorn");
 var walk = require("acorn/dist/walk");
 var path = require("path");
 var fs = require("fs");
+var readAll = require("fs-readdir-recursive")
 
 var mochaSettings = require("./mocha_settings");
 
@@ -27,10 +28,19 @@ module.exports = function () {
     if (folder.split(".").pop() === "js") {
       allFiles.push(folder);
     } else {
-      var files = fs.readdirSync(path.resolve(folder));
+      var files = [];
+      var folderName = folder;
+      // Check if folder ends with wildcard
+      if (folderName.match(/\/\*$/)) {
+        folderName = folderName.substring(0, folder.length - 2);
+        files = readAll(path.resolve(folderName)); 
+      }
+      else {
+        files = fs.readdirSync(path.resolve(folderName));
+      }
       if (files.length > 0) {
         allFiles = allFiles.concat(files.map(function (f) {
-          return path.resolve(folder) + "/" + f;
+          return path.resolve(folderName) + "/" + f;
         }));
       }
     }
@@ -43,6 +53,8 @@ module.exports = function () {
     return f.trim();
   });
 
+  // Remove possible duplicate files.
+  allFiles = _.uniq(allFiles);
 
   // Scan each file for calls to it("....");
   var tests = allFiles.map(function (filename) {


### PR DESCRIPTION
Users would be able to add mocha_tests folder "foo/bar/*" and be able to get all the mocha tests under "bar"