### PR TITLE
Support for tag filtering in mocha test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,38 @@ $ magellan --browser=chrome,firefox
 
 #### Controlling Which Tests Run
 
+##### Tag Support in Mocha-based Tests
+
+In Mocha-based tests, Magellan will find tags in `it()` strings in the form of a tagname preceded by an `@`. For example, to define a test that would match with `--tags=commerce` or `--tags=smoke`, we would write:
+
+```javascript
+it("should submit the purchase @commerce @smoke", function (done) {
+  ...
+});
+```
+
+##### Tag Support in Nightwatch.js-based Tests
+
+In Nightwatch-based tests, Magellan supports the standard Nightwatch convention of tags. To define a test that Magellan can match with `--tags=commerce` or `--tags=smoke`, we would write:
+
+```javascript
+module.exports = new Test({
+
+  tags: ["commerce", "smoke"],
+
+  "Load the order page": function (client) {
+    ...
+  },
+
+  "Submit the purchase": function (client) {
+    ...
+  }
+
+});
+```
+
+##### Selecting Tags at Runtime
+
 To filter by one or more tags, run `magellan` with the `--tag` or `--tags` option:
 ```console
 # Specify one tag:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "./bin/magellan"
   },
   "dependencies": {
-    "acorn": "^2.1.0",
+    "acorn": "2.1.0",
     "async": "^0.9.0",
     "cli-color": "^0.3.2",
     "cli-table": "^0.3.1",

--- a/src/interop/lib/get_mocha_tests.js
+++ b/src/interop/lib/get_mocha_tests.js
@@ -8,10 +8,9 @@ var mochaSettings = require("./mocha_settings");
 
 var sourceFolders = mochaSettings.mochaTestFolders;
 
-var Path = function (path, filename, id) {
+var Path = function (path, filename) {
   this.path = path;
   this.filename = filename;
-  this.id = id;
 };
 
 Path.prototype.toString = function () {
@@ -54,11 +53,7 @@ module.exports = function () {
     walk.findNodeAt(root, null, null, function (nodeType, node) {
       if (nodeType === "CallExpression" && node.callee.name === "it") {
         var name = node.arguments[0].value;
-        var id = "-----";
-        if (name.indexOf("[C") > -1 && name.indexOf("]") > -1) {
-          id = name.split("[")[1].split("]")[0];
-        }
-        children.push(new Path(name, filename, id));
+        children.push(new Path(name, filename));
       }
     });
     return children;

--- a/src/interop/lib/mocha_tag_filter.js
+++ b/src/interop/lib/mocha_tag_filter.js
@@ -30,17 +30,17 @@ module.exports = function(tags, f) {
   }
 
   walk.findNodeAt(root, null, null, function (nodeType, node) {
-    if (nodeType === "CallExpression" && node.callee.name === "it" && node.arguments[0].value === f.path) {
+    if (!pass && nodeType === "CallExpression" && node.callee.name === "it" && node.arguments[0].value === f.path) {
       var name = node.arguments[0].value;
-      name.split(" ").forEach(function (token) {
-        // chop off the @ at beginning of @tag
-        if (_.indexOf(tags, token.trim().substr(1)) > -1) {
-          // FIXME: this seems to match if even one tag matches.
-          // i.e. if the token we're currently looking at matches any of our *requested*
-          // tags, we match. Meaning --tags functions like an OR instead of an AND
-          pass = true;
-        }
-      })
+      var matchedTags = 0;
+      var nodeTags = name.split(" ");
+
+      // check if each of tags exists in this test case
+      if (tags.every(function (wantedTag) {
+        return nodeTags.indexOf("@" + wantedTag) > -1;
+      })) {
+        pass = true;
+      }
     }
   });
 

--- a/src/interop/lib/mocha_tag_filter.js
+++ b/src/interop/lib/mocha_tag_filter.js
@@ -1,0 +1,48 @@
+var path = require("path"),
+  fs = require("fs"),
+  _ = require("lodash"),
+  acorn = require("acorn"),
+  clc = require("cli-color"),
+  walk = require("acorn/dist/walk");
+
+module.exports = function(tags, f) {
+  // Filter by tag (or tag list):
+  //
+  // Parse the syntax tree of each included test and search for it() calls
+  // which have description strings containing the @tag we're looking for.
+  // Example:
+  //
+  //  it("should function correctly @basic")
+  //
+  // Match each f in files against the tag list we have in the array tags.
+  //
+  var foundTags = false;
+  var pass = false;
+  var filename = path.resolve(f.filename);
+  var root;
+  try {
+    root = acorn.parse(fs.readFileSync(filename), {
+      ecmaVersion: 6
+    });
+  } catch (err) {
+    console.log(clc.redBright("Syntax error in parsing " + filename));
+    throw err;
+  }
+
+  walk.findNodeAt(root, null, null, function (nodeType, node) {
+    if (nodeType === "CallExpression" && node.callee.name === "it" && node.arguments[0].value === f.path) {
+      var name = node.arguments[0].value;
+      name.split(" ").forEach(function (token) {
+        // chop off the @ at beginning of @tag
+        if (_.indexOf(tags, token.trim().substr(1)) > -1) {
+          // FIXME: this seems to match if even one tag matches.
+          // i.e. if the token we're currently looking at matches any of our *requested*
+          // tags, we match. Meaning --tags functions like an OR instead of an AND
+          pass = true;
+        }
+      })
+    }
+  });
+
+  return pass;
+};

--- a/src/interop/magellan-nightwatch/tag_filter.js
+++ b/src/interop/magellan-nightwatch/tag_filter.js
@@ -1,0 +1,49 @@
+var path = require("path"),
+  fs = require("fs"),
+  _ = require("lodash"),
+  acorn = require("acorn"),
+  clc = require("cli-color"),
+  walk = require("acorn/dist/walk");
+
+module.exports = function(tags, f) {
+  // Filter by tag (or tag list):
+  //
+  // Parse the syntax tree of each included test and search for a property
+  // definition with the name "tags" with an array expression attached to it,
+  // i.e. we're looking for source code in the following form:
+  //
+  //    tags: [ value, value, value ]
+  //
+  // Match each f in files against the tag list we have in the array tags.
+  //
+  var foundTags = false;
+  var pass = false;
+  var filename = path.resolve(f);
+  var root;
+  try {
+    root = acorn.parse(fs.readFileSync(filename), {
+      ecmaVersion: 6
+    });
+  } catch (err) {
+    console.log(clc.redBright("Syntax error in parsing " + filename));
+    throw err;
+  }
+
+  walk.findNodeAt(root, null, null, function (nodeType, node) {
+    if (!foundTags && nodeType === "Property") {
+      if (node.key && node.key.name === "tags" && node.value && node.value.type === "ArrayExpression" && node.value.elements) {
+        foundTags = true;
+        node.value.elements.forEach(function (tagNode) {
+          if (tagNode.value && typeof tagNode.value === "string") {
+            // FIXME: this seems to match if even one tag matches.
+            if (_.indexOf(tags, tagNode.value.trim()) > -1) {
+              pass = true;
+            }
+          }
+        });
+      }
+    }
+  });
+
+  return pass;
+};

--- a/src/interop/rowdy-mocha/tag_filter.js
+++ b/src/interop/rowdy-mocha/tag_filter.js
@@ -1,0 +1,1 @@
+module.exports = require("../lib/mocha_tag_filter");

--- a/src/interop/vanilla-mocha/tag_filter.js
+++ b/src/interop/vanilla-mocha/tag_filter.js
@@ -1,0 +1,1 @@
+module.exports = require("../lib/mocha_tag_filter");

--- a/src/test_filter.js
+++ b/src/test_filter.js
@@ -27,47 +27,9 @@ var filterByTags = function(files, tags) {
 
   console.log("Using tag filter: ", tags);
 
-  return files.filter(function (f) {
-    // Filter by tag (or tag list):
-    //
-    // Parse the syntax tree of each included test and search for a property
-    // definition with the name "tags" with an array expression attached to it,
-    // i.e. we're looking for source code in the following form:
-    //
-    //    tags: [ value, value, value ]
-    //
-    // Match each f in files against the tag list we have in the array tags.
-    //
-    var foundTags = false;
-    var pass = false;
-    var filename = path.resolve(f);
-    var root;
-    try {
-      root = acorn.parse(fs.readFileSync(filename), {
-        ecmaVersion: 6
-      });
-    } catch (err) {
-      console.log(clc.redBright("Syntax error in parsing " + filename));
-      throw err;
-    }
-
-    walk.findNodeAt(root, null, null, function (nodeType, node) {
-      if (!foundTags && nodeType === "Property") {
-        if (node.key && node.key.name === "tags" && node.value && node.value.type === "ArrayExpression" && node.value.elements) {
-          foundTags = true;
-          node.value.elements.forEach(function (tagNode) {
-            if (tagNode.value && typeof tagNode.value === "string") {
-              if (_.indexOf(tags, tagNode.value.trim()) > -1) {
-                pass = true;
-              }
-            }
-          });
-        }
-      }
-    });
-
-    return pass;
-  });
+  // FIXME: Handle an error with an interop that doesn't implement a tag_filter here
+  var filterImplementation = require("./interop/" + settings.framework + "/tag_filter");  
+  return files.filter(filterImplementation.bind(this, tags));
 };
 
 var PREDEFINED_FILTERS = {

--- a/test/test_runner.js
+++ b/test/test_runner.js
@@ -81,7 +81,7 @@ describe("test runner", function () {
       maxWorkers: MAX_WORKERS
     });
 
-    it("runs zero tests", function (done) {
+    it("runs zero tests @testtag @multi", function (done) {
       var options = _.extend({}, multiWorkerBaseOptions, {
         onSuccess: done
       });

--- a/test/test_runner.js
+++ b/test/test_runner.js
@@ -36,7 +36,7 @@ describe("test runner", function () {
       runner.start();
     });
 
-    it("runs one test", function (done) {
+    it("runs one test @testtag", function (done) {
       this.timeout(6000);
 
       var workerAllocator = new WorkerAllocator(MAX_WORKERS);
@@ -52,7 +52,7 @@ describe("test runner", function () {
       });
     });
 
-    it("fails one test", function (done) {
+    it("fails one test @testtag", function (done) {
       this.timeout(6000);
 
       var workerAllocator = new WorkerAllocator(MAX_WORKERS);


### PR DESCRIPTION
This PR adds the ability for magellan to filter tests by tag in mocha with `@tagname` support in `it()` strings.

/cc @geekdave 