### PR TITLE
Parse mocha tests in es6 mode

### DIFF
--- a/src/interop/lib/get_mocha_tests.js
+++ b/src/interop/lib/get_mocha_tests.js
@@ -46,7 +46,9 @@ module.exports = function () {
   // Scan each file for calls to it("....");
   var tests = allFiles.map(function (filename) {
     filename = path.resolve(filename);
-    var root = acorn.parse(fs.readFileSync(path.resolve(filename)));
+    var root = acorn.parse(fs.readFileSync(path.resolve(filename)), {
+      ecmaVersion: 6
+    });
     var children = [];
 
     // walk all nodes in JS syntax tree, hunt for CallExpressions of the form it("..");


### PR DESCRIPTION
This is the only instance of `acorn.parse` I could find that wasn't using `ecmaVersion: 6`. Had to add this to prevent this call from violently exploding in a project using ES6 with Mocha.