### PR TITLE
Fix crash in Slack reporter when accessing browser errors list

### DIFF
--- a/src/reporters/slack/slack.js
+++ b/src/reporters/slack/slack.js
@@ -87,7 +87,7 @@ Reporter.prototype.flush = function () {
   if (this.failures.length > 0) {
     var output = _.map(this.failures, function (failure, i) {
       var browserErrorsNote = "";
-      if (failure.browserErrors.length > 0) {
+      if (failure.browserErrors && failure.browserErrors.length > 0) {
         browserErrorsNote = "(uncaught errors: " + failure.browserErrors.length + " detected)";
       }
 


### PR DESCRIPTION
`failure.browserErrors` may not always exist. Protect against accessing `.length`