### PR TITLE
Add tests, more error handling, visual output for nightwatch get_tests functionality

### DIFF
--- a/src/interop/magellan-nightwatch/get_tests.js
+++ b/src/interop/magellan-nightwatch/get_tests.js
@@ -1,8 +1,17 @@
 var fs = require("fs");
 var path  = require("path");
 var settings = require("../../settings");
+var clc = require("cli-color");
 
 var nightwatchConfigFilePath = settings.nightwatchConfigFilePath;
+
+var filterFiles = function (files) {
+  return files.filter(function (f) {
+    return (f.indexOf(".js") === f.length - 3);
+  }).map(function (f) {
+    return f.trim();
+  });
+};
 
 module.exports = function () {
   var nightwatchConfig;
@@ -11,27 +20,36 @@ module.exports = function () {
     nightwatchConfig = require(path.resolve(nightwatchConfigFilePath));
     console.log("Magellan-nightwatch test iterator found nightwatch configuration at: " + nightwatchConfigFilePath);
   } catch (err) {
-    var error = "Magellan-nightwatch test iterator cannot read nightwatch configuration: " + err.toString();
-    return;
+    throw new Error("Magellan-nightwatch test iterator cannot read nightwatch configuration: " + err.toString());
+  }
+
+  if (!nightwatchConfig.src_folders) {
+    throw new Error("Magellan-nightwatch test iterator cannot find tests: src_folders in nightwatch configuration is missing");
+  }
+
+  if (nightwatchConfig.src_folders.length === 0) {
+    throw new Error("Magellan-nightwatch test iterator cannot find tests: src_folders in nightwatch configuration is present, but empty");
   }
 
   var srcFolders = nightwatchConfig.src_folders;
 
   var allFiles = [];
   srcFolders.forEach(function (folder) {
-    var files = fs.readdirSync(path.normalize(folder));
+    var p = path.normalize(folder);
+    console.log("Scanning " + p + " for test files ...");
+    var files = fs.readdirSync(p);
+
     if (files.length > 0) {
-      allFiles = allFiles.concat(files.map(function (f) {
+      var additionalFiles = filterFiles(files.map(function (f) {
         return path.normalize(folder) + "/" + f;
       }));
+      if (additionalFiles.length > 0 ) {
+        console.log(clc.green("Found " + additionalFiles.length + " test files in " + p));
+      } else {
+        console.log(clc.yellow("Found no test files in " + p));
+      }
+      allFiles = allFiles.concat(additionalFiles);
     }
-  });
-
-  // Ensure we scan for JS only, ignoring README files, etc.
-  allFiles = allFiles.filter(function (f) {
-    return (f.indexOf(".js") === f.length - 3);
-  }).map(function (f) {
-    return f.trim();
   });
 
   return allFiles;

--- a/test/nightwatch_test_iteration_and_filtering.js
+++ b/test/nightwatch_test_iteration_and_filtering.js
@@ -1,0 +1,57 @@
+var chai = require("chai");
+var expect = chai.expect;
+
+// Note: must inject settings before we require get_tests
+var settings = require("../src/settings");
+settings.framework = "magellan-nightwatch";
+settings.nightwatchConfigFilePath = "./test_support/mock_nightwatch_config.json";
+
+var testFilter = require("../src/test_filter");
+var getTests = require("../src/interop/magellan-nightwatch/get_tests");
+
+var _ = require("lodash");
+
+describe("nightwatch support", function () {
+
+  describe("test iterator", function () {
+
+    it("finds tests", function () {
+      var tests = getTests();
+      expect(tests).to.have.length(3);
+    });
+
+    it("finds tests with a tag filter", function () {
+      var tests = getTests();
+      var activeFilters = testFilter.detectFromCLI({"tags": "search"});
+      var filteredTests = testFilter.filter(tests, activeFilters);
+
+      expect(filteredTests).to.have.length(2);
+    });
+
+    it("finds fewer tests with a tag filter containing more matched tags", function () {
+      var tests = getTests();
+      var activeFilters = testFilter.detectFromCLI({"tags": "search,mobile"});
+      var filteredTests = testFilter.filter(tests, activeFilters);
+
+      expect(filteredTests).to.have.length(1);
+    });
+
+    it("finds no tests with an unmatched tag filter containing some matching tags", function () {
+      var tests = getTests();
+      var activeFilters = testFilter.detectFromCLI({"tags": "search,mobile,abc123"});
+      var filteredTests = testFilter.filter(tests, activeFilters);
+
+      expect(filteredTests).to.have.length(0);
+    });
+
+    it("finds no tests with an unmatched tag filter", function () {
+      var tests = getTests();
+      var activeFilters = testFilter.detectFromCLI({"tags": "abc123"});
+      var filteredTests = testFilter.filter(tests, activeFilters);
+
+      expect(filteredTests).to.have.length(0);
+    });
+
+  });
+
+});

--- a/test_support/mock_nightwatch_config.json
+++ b/test_support/mock_nightwatch_config.json
@@ -1,0 +1,5 @@
+{
+  "src_folders": [
+    "./test_support/mock_nightwatch_tests"
+  ]
+}

--- a/test_support/mock_nightwatch_tests/search.js
+++ b/test_support/mock_nightwatch_tests/search.js
@@ -1,0 +1,18 @@
+var Test = require("../lib/example-base-test-class");
+
+module.exports = new Test({
+
+  tags: ["search", "web"],
+
+  "Test step one": function (client) {
+    client
+      .url("http://google.com");
+  },
+
+  "Test step two": function (client) {
+    client
+      .assert.elContainsText("body", "Google")
+  }
+
+
+});

--- a/test_support/mock_nightwatch_tests/search_mobile.js
+++ b/test_support/mock_nightwatch_tests/search_mobile.js
@@ -1,0 +1,18 @@
+var Test = require("../lib/example-base-test-class");
+
+module.exports = new Test({
+
+  tags: ["search", "mobile"],
+
+  "Test step one": function (client) {
+    client
+      .url("http://google.com/mobile");
+  },
+
+  "Test step two": function (client) {
+    client
+      .assert.elContainsText("body", "Google")
+  }
+
+
+});

--- a/test_support/mock_nightwatch_tests/wiki.js
+++ b/test_support/mock_nightwatch_tests/wiki.js
@@ -1,0 +1,18 @@
+var Test = require("../lib/example-base-test-class");
+
+module.exports = new Test({
+
+  tags: ["wiki"],
+
+  "Test step one": function (client) {
+    client
+      .url("http://en.wikipedia.org");
+  },
+
+  "Test step two": function (client) {
+    client
+      .assert.elContainsText("body", "Wikipedia")
+  }
+
+
+});


### PR DESCRIPTION
In the spirit of beefing up our test coverage and reducing irony factor (as mentioned by @mattfysh here https://github.com/TestArmada/magellan/pull/78 ), this PR preps for future tag filtering changes with some tests.

This PR adds:
  - Some unit tests for `get_tests()` in nightwatch support
  - Some more/better error handling in `get_tests()` (in nightwatch mode only) 
  - Better visual output for what `get_tests()` is doing (in nightwatch mode only)
  - A simple mock nightwatch test suite.

In the future, we want to be able to have `--tags` function in `OR` mode in addition the current `AND` mode, so adding tests before we add those functions is critical.

cc @geekdave