### PR TITLE
Add eslint to build for src/* and bin/*

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,3 +9,4 @@ rules:
   "no-extra-bind": 0
   "max-params": [2, 7]
   "max-statements": 0
+  "no-process-exit": 0

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test": "./bin/magellan"
+    "test": "eslint src/** bin/** && ./bin/magellan"
   },
   "dependencies": {
     "acorn": "2.1.0",

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -653,7 +653,8 @@ TestRunner.prototype = {
 
   // Return true if this build should stop running and fail immediately.
   shouldBail: function () {
-    if (this.strictness === strictness.BAIL_NEVER || this.strictness === strictness.BAIL_TIME_ONLY) {
+    if (this.strictness === strictness.BAIL_NEVER
+      || this.strictness === strictness.BAIL_TIME_ONLY) {
       // BAIL_NEVER means we don't apply any strictness rules at all
       return false;
     } else if (this.strictness === strictness.BAIL_EARLY) {


### PR DESCRIPTION
This PR adds `eslint` to the build. Notes:
  - There are many `eslint-disable` spots, but our intent should be to cover those spots with tests where necessary and work to reduce our lint-disables where sensible. `FIXME` notes have been added for the most egregious cases or where I want to make good but not in the scope of a housekeeping PR.
  - Only `src/*` and `bin/*` are being scanned. Tests, test support, etc are TODO

/cc @geekdave 