### PR TITLE
Fix saucelabs URL

### DIFF
--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -298,7 +298,7 @@ TestRunner.prototype = {
           //       generates a resultURL, but in the future, we may have resultURLs that
           //       originate from somewhere else.
           //
-          resultURL: "https://saucelabs.com/" + seleniumSessionId
+          resultURL: "https://saucelabs.com/tests/" + seleniumSessionId
         }
       });
 


### PR DESCRIPTION
This PR fixes the incorrect saucelabs URL string in `test_runner`.

/cc @geekdave 