### PR TITLE
Log tempdir, update s-c-launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "q": "1.0.1",
     "qs": "2.2.4",
     "request": "^2.55.0",
-    "sauce-connect-launcher": "0.11.0",
+    "sauce-connect-launcher": "^0.14.0",
     "slugify": "^0.1.1",
     "sync-request": "^2.0.1",
     "yargs": "1.3.2"

--- a/src/settings.js
+++ b/src/settings.js
@@ -14,6 +14,7 @@ var buildId = argv.external_build_id || "magellan-"
 var mkdirSync = require("./mkdir_sync");
 var TEMP_DIR = argv.temp_dir || "./temp";
 var path = require("path");
+console.log("Magellan is creating temporary files at: " + path.resolve(TEMP_DIR));
 mkdirSync(path.resolve(TEMP_DIR));
 
 module.exports = {


### PR DESCRIPTION
Update `sauce-connect-launcher`, verbosely output where Magellan is outputting its temp files to the console.

/cc @geekdave 