### PR TITLE
Allocator analytics

### DIFF
--- a/src/sauce/worker_allocator.js
+++ b/src/sauce/worker_allocator.js
@@ -10,11 +10,10 @@ var exec = require("child_process").exec;
 var sauceSettings = require("./settings");
 var settings = require("../settings");
 var analytics = require("../global_analytics");
+var guid = require("../util/guid");
 
 var tunnel = require("./tunnel");
 var BASE_SELENIUM_PORT_OFFSET = 56000;
-var TUNNEL_PREFIX_RAND_MAX = 99999;
-var STRNUM_BASE = 16;
 var SECOND_MS = 1000;
 var SECONDS_MINUTE = 60;
 
@@ -33,7 +32,7 @@ function SauceWorkerAllocator(_MAX_WORKERS) {
   this.tunnelErrors = [];
   this.MAX_WORKERS = _MAX_WORKERS;
   this.maxTunnels = sauceSettings.maxTunnels;
-  this.tunnelPrefix = Math.round(Math.random() * TUNNEL_PREFIX_RAND_MAX).toString(STRNUM_BASE);
+  this.tunnelPrefix = guid();
 
   if (sauceSettings.locksServerLocation) {
     console.log("Using locks server at " + sauceSettings.locksServerLocation

--- a/src/settings.js
+++ b/src/settings.js
@@ -2,13 +2,13 @@
 
 /*eslint-disable no-magic-numbers*/
 
+var guid = require("./util/guid");
 var argv = require("marge").argv;
 var env = process.env;
 
 // Allow an external build id (eg: from CI system, for example) to be used. If we're not given one,
 // we generate a random build id instead. NOTE: This build id must work as a part of a filename.
-var buildId = argv.external_build_id || "magellan-"
-  + Math.round(Math.random() * 9999999999).toString(16);
+var buildId = argv.external_build_id || "magellan-" + guid();
 
 // Create a temporary directory for child build assets like configuration, screenshots, etc.
 var mkdirSync = require("./mkdir_sync");

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -12,15 +12,13 @@ var once = require("once");
 var EventEmitter = require("events").EventEmitter;
 var fs = require("fs");
 var mkdirSync = require("./mkdir_sync");
+var guid = require("./util/guid");
 
 var sauceBrowsers = require("./sauce/browsers");
 var analytics = require("./global_analytics");
 
 var settings = require("./settings");
 var Test = require("./test");
-
-var RAND_SIZE = 9999999999;
-var STRNUM_BASE = 16;
 
 var WORKER_START_DELAY = 1000;
 var WORKER_STOP_DELAY = 1500;
@@ -157,8 +155,14 @@ TestRunner.prototype = {
   // Prepare a test to be run. Find a worker for the test and send it off to be run.
   stageTest: function (test, onTestComplete) {
     var self = this;
+    var analyticsGuid = guid();
+
+    analytics.push("acquire-worker-" + analyticsGuid);
+
     this.allocator.get(function (error, worker) {
       if (!error) {
+        analytics.mark("acquire-worker-" + analyticsGuid);
+
         this.runTest(test, worker)
           .then(function (runResults) {
             // Give this worker back to the allocator
@@ -198,6 +202,7 @@ TestRunner.prototype = {
             onTestComplete(runTestError, test);
           });
       } else {
+        analytics.mark("acquire-worker", "failed");
         // If the allocator could not give us a worker, pass
         // back a failed test result with the allocator's error.
         console.error("Worker allocator error: " + error);
@@ -452,7 +457,7 @@ TestRunner.prototype = {
 
     try {
       var TestRunClass = settings.testFramework.TestRun;
-      var childBuildId = Math.round(Math.random() * RAND_SIZE).toString(STRNUM_BASE);
+      var childBuildId = guid();
       var tempAssetPath = path.resolve(settings.tempDir + "/build-" + this.buildId + "_"
         + childBuildId + "__temp_assets");
       mkdirSync(tempAssetPath);

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -202,7 +202,7 @@ TestRunner.prototype = {
             onTestComplete(runTestError, test);
           });
       } else {
-        analytics.mark("acquire-worker", "failed");
+        analytics.mark("acquire-worker-" + analyticsGuid, "failed");
         // If the allocator could not give us a worker, pass
         // back a failed test result with the allocator's error.
         console.error("Worker allocator error: " + error);

--- a/src/util/guid.js
+++ b/src/util/guid.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var RAND_MAX = 9999999999999999;
+var STRNUM_BASE = 16;
+
+module.exports = function () {
+  return Math.round(Math.random() * RAND_MAX).toString(STRNUM_BASE);
+};


### PR DESCRIPTION
This PR:

  - Moves all cases where we do `Math.round(Math.random() * 99999).toString(16)` to `util/guid`.
  - Introduces `acquire-worker-*****` to analytics output, for tracking how long it takes to acquire workers from the worker allocator (either directly or through an intermediary like https://github.com/TestArmada/locks )

/cc @geekdave @archlichking 