### PR TITLE
Track idle and busy states in analytics

### DIFF
--- a/bin/magellan
+++ b/bin/magellan
@@ -59,6 +59,7 @@ var magellanGlobals = {
 };
 
 analytics.push("magellan-run");
+analytics.push("magellan-busy", undefined, "idle");
 
 //
 // Initialize Framework Plugins

--- a/src/global_analytics.js
+++ b/src/global_analytics.js
@@ -14,7 +14,7 @@ module.exports = {
   //
   // NOTE: name must be unique if non-colliding markers are desired.
   push: function (eventName, metadata, startMarkerName) {
-    startMarkerName = startMarkerName ? "start";
+    startMarkerName = startMarkerName ? startMarkerName : "start";
 
     var ev = {
       type: "analytics-event",

--- a/src/global_analytics.js
+++ b/src/global_analytics.js
@@ -13,14 +13,16 @@ module.exports = {
   // receive the event. A markers list will be started with the current time.
   //
   // NOTE: name must be unique if non-colliding markers are desired.
-  push: function (eventName, metadata) {
+  push: function (eventName, metadata, startMarkerName) {
+    startMarkerName = startMarkerName ? "start";
+
     var ev = {
       type: "analytics-event",
       data: {
         name: eventName,
 
         markers: [{
-          name: "start",
+          name: startMarkerName,
           t: Date.now()
         }],
 


### PR DESCRIPTION
This PR adds idle/busy tracking to `test_runner`, which in turn emits analytics events useful for tracking whether magellan is busy or idle, and for how long. Markers for `magellan-busy` are continuously marked **on the same event**, so this is thus far the only magellan analytics event that generates more than 2 markers in its lifecycle. This yields a marker pattern of:

`idle` -> `busy` -> `idle` -> `busy` -> [ ... ] - > `idle`

Examining the markers from a reporter can yield data which shows how much time magellan spent busy and how much time it spent idle.

/cc @geekdave 