### PR TITLE
Use map with shorthand as pluck is removed in lodash 4

### DIFF
--- a/src/sauce/browsers.js
+++ b/src/sauce/browsers.js
@@ -24,7 +24,7 @@ module.exports = {
       return f.length;
     }).length + PADDING;
 
-    var maxCLIWidth = _.max(_.pluck(browsers, "id"), function (b) {
+    var maxCLIWidth = _.max(_.map(browsers, "id"), function (b) {
       return b.length;
     }).length + cliSuffix.length + PADDING;
 
@@ -40,7 +40,7 @@ module.exports = {
       return b.toString().length;
     }).length + PADDING;
 
-    var maxOSWidth = _.max(_.pluck(browsers, "desiredCapabilities.platform"), function (b) {
+    var maxOSWidth = _.max(_.map(browsers, "desiredCapabilities.platform"), function (b) {
       return b.length;
     }).length + PADDING;
 


### PR DESCRIPTION
This fixes the following error.

```
➜  magellan git:(master) bin/magellan --list_browsers
Magellan 8.4.0
Will try to load configuration from default of ./magellan.json
Loaded configuration from:  /Users/danielvicory/usr/src/magellan/magellan.json
Magellan is creating temporary files at: /Users/danielvicory/usr/src/magellan/temp
Sauce configuration OK
Couldn't fetch browsers. Error:  [TypeError: _.pluck is not a function]
TypeError: _.pluck is not a function
    at Object.module.exports.listBrowsers (/Users/danielvicory/usr/src/magellan/src/sauce/browsers.js:27:31)
    at /Users/danielvicory/usr/src/magellan/bin/magellan:126:14
    at _fulfilled (/Users/danielvicory/usr/src/magellan/node_modules/guacamole/node_modules/q/q.js:834:54)
    at self.promiseDispatch.done (/Users/danielvicory/usr/src/magellan/node_modules/guacamole/node_modules/q/q.js:863:30)
    at Promise.promise.promiseDispatch (/Users/danielvicory/usr/src/magellan/node_modules/guacamole/node_modules/q/q.js:796:13)
    at /Users/danielvicory/usr/src/magellan/node_modules/guacamole/node_modules/q/q.js:604:44
    at runSingle (/Users/danielvicory/usr/src/magellan/node_modules/guacamole/node_modules/q/q.js:137:13)
    at flush (/Users/danielvicory/usr/src/magellan/node_modules/guacamole/node_modules/q/q.js:125:13)
    at doNTCallback0 (node.js:428:9)
    at process._tickCallback (node.js:357:13)
```