### PR TITLE
Make Early Bail Configurable via args/env, Clearer Bail Logging

### DIFF
--- a/src/cli_help.js
+++ b/src/cli_help.js
@@ -18,6 +18,8 @@ module.exports = {
     console.log("  --bail_early                 Kill builds that have failed at least 10% of tests, after 10 or more test runs.");
     console.log("  --bail_fast                  Kill builds that fail any test.");
     console.log("  --bail_time                  Set test kill time in milliseconds. *CAN* be used without bail_early/bail_fast.");
+    console.log("  --early_bail_threshold       A decimal ratio (eg 0.25 for 25%) how many tests to fail before bail_early");
+    console.log("  --early_bail_min_attempts    How many test runs to run before applying bail_early rule.");
     console.log("  --debug                      Enable debugging magellan messages (dev mode).");
     console.log("");
     console.log(" Configuration:");

--- a/src/settings.js
+++ b/src/settings.js
@@ -50,8 +50,8 @@ module.exports = {
   // For --bail_early, we have two settings:
   // threshold: the ratio (out of 1) of how many tests we need to see fail before we bail early.
   // min attempts: how many tests we need to see first before we apply the threshold
-  bailThreshold: argv.early_bail_threshold || env.MAGELLAN_EARLY_BAIL_THRESHOLD || 0.1,
-  bailMinAttempts: argv.early_bail_min_attempts || env.MAGELLAN_EARLY_BAIL_MIN_ATTEMPTS || 10,
+  bailThreshold: argv.early_bail_threshold || 0.1,
+  bailMinAttempts: argv.early_bail_min_attempts || 10,
 
   buildId: buildId,
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -50,8 +50,8 @@ module.exports = {
   // For --bail_early, we have two settings:
   // threshold: the ratio (out of 1) of how many tests we need to see fail before we bail early.
   // min attempts: how many tests we need to see first before we apply the threshold
-  bailThreshold: argv.early_bail_threshold || 0.1,
-  bailMinAttempts: argv.early_bail_min_attempts || 10,
+  bailThreshold: parseFloat(argv.early_bail_threshold) || 0.1,
+  bailMinAttempts: parseInt(argv.early_bail_min_attempts) || 10,
 
   buildId: buildId,
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -47,6 +47,12 @@ module.exports = {
   bailTime: argv.bail_time || 8 * 60 * 1000,
   bailTimeExplicitlySet: typeof argv.bail_time !== "undefined",
 
+  // For --bail_early, we have two settings:
+  // threshold: the ratio (out of 1) of how many tests we need to see fail before we bail early.
+  // min attempts: how many tests we need to see first before we apply the threshold
+  bailThreshold: argv.early_bail_threshold || env.MAGELLAN_EARLY_BAIL_THRESHOLD || 0.1,
+  bailMinAttempts: argv.early_bail_min_attempts || env.MAGELLAN_EARLY_BAIL_MIN_ATTEMPTS || 10,
+
   buildId: buildId,
 
   framework: argv.framework || "nightwatch",

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -32,9 +32,9 @@ var strictness = {
   BAIL_FAST: 4,      // bail as soon as a test fails, apply time rules
 
   // Ratio of tests that need to fail before we abandon the build in BAIL_EARLY mode
-  THRESHOLD: 0.1,
+  THRESHOLD: settings.bailThreshold,
   // Minimum number of tests that need to run before we test threshold rules
-  THRESHOLD_MIN_ATTEMPTS: 10,
+  THRESHOLD_MIN_ATTEMPTS: settings.bailMinAttempts,
 
   // Running length after which we abandon and fail a test in any mode except BAIL_NEVER
   // Specified in milliseconds.
@@ -773,6 +773,9 @@ TestRunner.prototype = {
 
       if (totalAttempts > strictness.THRESHOLD_MIN_ATTEMPTS) {
         if (ratio > strictness.THRESHOLD) {
+          console.log("Magellan has seen at least " + (strictness.THRESHOLD * 100) + "% of "
+            + " tests fail after seeing at least " + strictness.THRESHOLD_MIN_ATTEMPTS
+            + " tests run. Bailing early.");
           return true;
         }
       }


### PR DESCRIPTION
This PR allows `--bail_early` to have its threshold and minimum test runs settings set.

Added:
  - CLI help for both new options
  - Clarification to log output of bail settings when early bail kicks in.

/cc @geekdave @archlichking 