### PR TITLE
Sanitize string used for temporary asset directory path. Check TEMP_DIR exists and is r-w-able

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "q": "1.0.1",
     "qs": "2.2.4",
     "request": "^2.55.0",
+    "sanitize-filename": "^1.5.3",
     "sauce-connect-launcher": "^0.14.0",
     "slugify": "^0.1.1",
     "sync-request": "^2.0.1",

--- a/src/settings.js
+++ b/src/settings.js
@@ -17,8 +17,11 @@ var mkdirSync = require("./mkdir_sync");
 var TEMP_DIR = path.resolve(argv.temp_dir || "./temp");
 
 try {
-  // Check if TEMP_DIR already exists
-  fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK);
+  // Check if TEMP_DIR already exists.
+  // NOTE: This doesn't work in node 0.10. Those envs will suffer as a result
+  if (fs.accessSync) {
+    fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK);
+  }
 } catch (e) {
   // Create it if it doesn't..
   mkdirSync(TEMP_DIR);
@@ -26,7 +29,10 @@ try {
 
 try {
   // Check if creation worked or if we have access to the directory we were told to use.
-  fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK);
+  // NOTE: This doesn't work in node 0.10. Those envs will suffer as a result
+  if (fs.accessSync) {
+    fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK);
+  }
   console.log("Magellan is creating temporary files at: " + TEMP_DIR);
 } catch (e) {
   throw new Error("Magellan cannot write to or create the temporary directory: " + TEMP_DIR);

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,11 +1,12 @@
 "use strict";
 
-/*eslint-disable no-magic-numbers*/
+/*eslint-disable no-magic-numbers, no-bitwise*/
 
 var guid = require("./util/guid");
 var argv = require("marge").argv;
 var env = process.env;
 var fs = require("fs");
+var path = require("path");
 
 // Allow an external build id (eg: from CI system, for example) to be used. If we're not given one,
 // we generate a random build id instead. NOTE: This build id must work as a part of a filename.
@@ -14,7 +15,6 @@ var buildId = argv.external_build_id || "magellan-" + guid();
 // Create a temporary directory for child build assets like configuration, screenshots, etc.
 var mkdirSync = require("./mkdir_sync");
 var TEMP_DIR = path.resolve(argv.temp_dir || "./temp");
-var path = require("path");
 
 if (fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK)) {
   console.log("Magellan is creating temporary files at: " + TEMP_DIR);

--- a/src/settings.js
+++ b/src/settings.js
@@ -5,6 +5,7 @@
 var guid = require("./util/guid");
 var argv = require("marge").argv;
 var env = process.env;
+var fs = require("fs");
 
 // Allow an external build id (eg: from CI system, for example) to be used. If we're not given one,
 // we generate a random build id instead. NOTE: This build id must work as a part of a filename.
@@ -12,10 +13,16 @@ var buildId = argv.external_build_id || "magellan-" + guid();
 
 // Create a temporary directory for child build assets like configuration, screenshots, etc.
 var mkdirSync = require("./mkdir_sync");
-var TEMP_DIR = argv.temp_dir || "./temp";
+var TEMP_DIR = path.resolve(argv.temp_dir || "./temp");
 var path = require("path");
-console.log("Magellan is creating temporary files at: " + path.resolve(TEMP_DIR));
-mkdirSync(path.resolve(TEMP_DIR));
+
+if (fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK)) {
+  console.log("Magellan is creating temporary files at: " + TEMP_DIR);
+} else {
+  throw new Error("Magellan cannot write to the temporary directory: " + TEMP_DIR);
+}
+
+mkdirSync(TEMP_DIR);
 
 module.exports = {
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -16,9 +16,10 @@ var buildId = argv.external_build_id || "magellan-" + guid();
 var mkdirSync = require("./mkdir_sync");
 var TEMP_DIR = path.resolve(argv.temp_dir || "./temp");
 
-if (fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK)) {
+try {
+  fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK);
   console.log("Magellan is creating temporary files at: " + TEMP_DIR);
-} else {
+} catch (e) {
   throw new Error("Magellan cannot write to the temporary directory: " + TEMP_DIR);
 }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -21,6 +21,8 @@ try {
   // NOTE: This doesn't work in node 0.10. Those envs will suffer as a result
   if (fs.accessSync) {
     fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK);
+  } else {
+    throw new Error("old node version");
   }
 } catch (e) {
   // Create it if it doesn't..
@@ -30,6 +32,8 @@ try {
 try {
   // Check if creation worked or if we have access to the directory we were told to use.
   // NOTE: This doesn't work in node 0.10. Those envs will suffer as a result
+  // if we don't have accessSync, then we proceed without being sure about TEMP_DIR.
+  // A crash will occur LATER in old node versions
   if (fs.accessSync) {
     fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK);
   }

--- a/src/settings.js
+++ b/src/settings.js
@@ -17,13 +17,21 @@ var mkdirSync = require("./mkdir_sync");
 var TEMP_DIR = path.resolve(argv.temp_dir || "./temp");
 
 try {
+  // Check if TEMP_DIR already exists
+  fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK);
+} catch (e) {
+  // Create it if it doesn't..
+  mkdirSync(TEMP_DIR);
+}
+
+try {
+  // Check if creation worked or if we have access to the directory we were told to use.
   fs.accessSync(TEMP_DIR, fs.R_OK | fs.W_OK);
   console.log("Magellan is creating temporary files at: " + TEMP_DIR);
 } catch (e) {
-  throw new Error("Magellan cannot write to the temporary directory: " + TEMP_DIR);
+  throw new Error("Magellan cannot write to or create the temporary directory: " + TEMP_DIR);
 }
 
-mkdirSync(TEMP_DIR);
 
 module.exports = {
 

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -13,6 +13,7 @@ var EventEmitter = require("events").EventEmitter;
 var fs = require("fs");
 var mkdirSync = require("./mkdir_sync");
 var guid = require("./util/guid");
+var sanitizeFilename = require("sanitize-filename");
 
 var sauceBrowsers = require("./sauce/browsers");
 var analytics = require("./global_analytics");
@@ -482,8 +483,11 @@ TestRunner.prototype = {
     try {
       var TestRunClass = settings.testFramework.TestRun;
       var childBuildId = guid();
-      var tempAssetPath = path.resolve(settings.tempDir + "/build-" + this.buildId + "_"
+
+      // Note: we must sanitize the buildid because it might contain slashes or ".."" and other bad stuff
+      var tempAssetPath = path.resolve(settings.tempDir + "/build-" + sanitizeFilename(this.buildId) + "_"
         + childBuildId + "__temp_assets");
+
       mkdirSync(tempAssetPath);
 
       testRun = new TestRunClass({

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -484,9 +484,9 @@ TestRunner.prototype = {
       var TestRunClass = settings.testFramework.TestRun;
       var childBuildId = guid();
 
-      // Note: we must sanitize the buildid because it might contain slashes or ".."" and other bad stuff
-      var tempAssetPath = path.resolve(settings.tempDir + "/build-" + sanitizeFilename(this.buildId) + "_"
-        + childBuildId + "__temp_assets");
+      // Note: we must sanitize the buildid because it might contain slashes or "..", etc
+      var tempAssetPath = path.resolve(settings.tempDir + "/build-"
+        + sanitizeFilename(this.buildId) + "_" + childBuildId + "__temp_assets");
 
       mkdirSync(tempAssetPath);
 


### PR DESCRIPTION
Fixes #138 

Also checks if the resolved `TEMP_DIR` is writable, and calls `path.resolve` on `TEMP_DIR` before we add it to the global settings object.

/cc @geekdave 