### PR TITLE
Export port checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,6 @@ Where `browser_profiles.json` should have a structure similar to placing `profil
   }
 ```
 
-
 Setting Up Setup and Teardown Tasks for CI
 ==========================================
 
@@ -601,6 +600,26 @@ Here's an example `scripts` block that implements these tasks in your package.js
     "magellan:setup": "./path/to/my/setup.sh",
     "magellan:teardown": "./path/to/my/teardown.sh"
   },
+```
+
+Using Magellan's Port Acquisition and Scanning Facilities
+=========================================================
+
+If you need to be able to consume ports during a magellan run and want to be absolutely certain they won't conflict with those that magellan gives to its worker pool, you can use the `portUtils` submodule like this in your setup and teardown tasks:
+
+```javascript
+
+var magellan = require("testarmada-magellan");
+
+// calls callback with arguments [null, 12000] if successful
+magellan.portUtil.acquirePort(function(err, port) {
+  if (err) {
+    console.log("error!", err);
+  } else {
+    console.log("Got port " + port + " for safe usage.");
+  }
+});
+
 ```
 
 ## Licenses

--- a/src/main.js
+++ b/src/main.js
@@ -2,5 +2,6 @@
 /*eslint-disable global-require*/
 
 module.exports = {
-  Reporter: require("./reporters/reporter")
+  Reporter: require("./reporters/reporter"),
+  portUtil: require("./util/port_util")
 };

--- a/src/util/check_ports.js
+++ b/src/util/check_ports.js
@@ -24,6 +24,15 @@ var checkPortStatus = function (desiredPort, callback) {
   });
 };
 
+//
+// Given an array portNumbers of the form:
+//
+// [1234, 5678, ...]
+//
+// checkPortRange will call callback() with a list of port statuses in the form:
+//
+// [{ port: number, available: boolean }]
+//
 var checkPortRange = function (portNumbers, callback) {
   portNumbers = _.cloneDeep(portNumbers);
   var statuses = [];

--- a/src/util/port_util.js
+++ b/src/util/port_util.js
@@ -1,0 +1,57 @@
+"use strict";
+
+var settings = require("../settings");
+var checkPorts = require("./check_ports");
+
+var MAX_ACQUIRE_ATTEMPTS = 100;
+var MAX_PORT = settings.BASE_PORT_START + settings.BASE_PORT_RANGE - 1;
+var portCursor;
+
+var util = {
+
+  // Return magellan's internal port cursor, i.e. the next port that can potentially
+  // be probed for availability. This doesn't perform a port contention check. Calling
+  // this function also ticks the port cursor upwards regardless of result.
+  getNextPort: function () {
+    // Reset back to start of range
+    if (typeof portCursor === "undefined" || portCursor + settings.BASE_PORT_SPACING > MAX_PORT) {
+      portCursor = settings.BASE_PORT_START;
+    }
+
+    // Choose the next port
+    var nextPort = portCursor;
+
+    // Allocate the port for the next worker -- or spill over the range
+    portCursor = portCursor + settings.BASE_PORT_SPACING;
+    return nextPort;
+  },
+
+  // Call callback(err, foundPort) with either:
+  //
+  // 1) an Error object, if we couldnt' find a port
+  // 2) null and a foundPort as the second argument
+  acquirePort: function (callback) {
+    var attempts = 0;
+    var acquire = function () {
+      checkPorts([util.getNextPort()], function (result) {
+        if (result[0].available) {
+          return callback(null, result[0].port);
+        } else {
+          attempts++;
+          if (attempts > MAX_ACQUIRE_ATTEMPTS) {
+            return callback(new Error("Gave up looking for an available port after "
+              + MAX_ACQUIRE_ATTEMPTS + " attempts."));
+          } else {
+            acquire();
+          }
+        }
+      });
+    };
+
+    acquire();
+  },
+
+  checkPorts: checkPorts
+};
+
+module.exports = util;

--- a/src/worker_allocator.js
+++ b/src/worker_allocator.js
@@ -3,34 +3,12 @@
 var _ = require("lodash");
 var clc = require("cli-color");
 var settings = require("./settings");
-var checkPortRange = require("./util/check_port_range");
-
-var BASE_PORT_START = settings.BASE_PORT_START;
-var BASE_PORT_RANGE = settings.BASE_PORT_RANGE;
-var BASE_PORT_SPACING = settings.BASE_PORT_SPACING;
-
-var BASE_PORT_OFFSET = BASE_PORT_START;
-var MAX_PORT = BASE_PORT_START + BASE_PORT_RANGE - 1;
+var portUtil = require("./util/port_util");
+var checkPorts = portUtil.checkPorts;
+var getNextPort = portUtil.getNextPort;
 
 var MAX_ALLOCATION_ATTEMPTS = 120;
 var WORKER_START_DELAY = 1000;
-
-var portCursor;
-
-// Return the next port to be used. This doesn't perform a port contention check
-var getNextPort = function () {
-  // Reset back to start of range
-  if (typeof portCursor === "undefined" || portCursor + BASE_PORT_SPACING > MAX_PORT) {
-    portCursor = BASE_PORT_OFFSET;
-  }
-
-  // Choose the next port
-  var nextPort = portCursor;
-
-  // Allocate the port for the next worker -- or spill over the range
-  portCursor = portCursor + BASE_PORT_SPACING;
-  return nextPort;
-};
 
 // Create a worker allocator for MAX_WORKERS workers. Note that the allocator
 // is not obliged to honor the creation of MAX_WORKERS, just some number of workers
@@ -38,8 +16,9 @@ var getNextPort = function () {
 function Allocator(MAX_WORKERS) {
   if (settings.debug) {
     console.log("Worker Allocator starting.");
-    console.log("Port allocation range from: " + BASE_PORT_OFFSET + " to " + MAX_PORT + " with "
-      + BASE_PORT_SPACING + " ports available to each worker.");
+    console.log("Port allocation range from: " + settings.BASE_PORT_START + " to "
+      + (settings.BASE_PORT_START + settings.BASE_PORT_RANGE - 1) + " with "
+      + settings.BASE_PORT_SPACING + " ports available to each worker.");
   }
 
   this.initializeWorkers(MAX_WORKERS);
@@ -109,11 +88,11 @@ Allocator.prototype = {
       var desiredPorts = [];
 
       // if BASE_PORT_SPACING is the default of 3, we'll check 3 ports
-      for (var i = 0; i < BASE_PORT_SPACING; i++) {
+      for (var i = 0; i < settings.BASE_PORT_SPACING; i++) {
         desiredPorts.push(portOffset + i);
       }
 
-      checkPortRange(desiredPorts, function (statuses) {
+      checkPorts(desiredPorts, function (statuses) {
         if (_.every(statuses, function (status) { return status.available; })) {
           availableWorker.portOffset = portOffset;
           availableWorker.occupied = true;


### PR DESCRIPTION
This PR gives our users access to Magellan's port acquisition facilities, and allows users to **share Magellan's port cursor**. This ensures users are not stepping on top of Magellan's own guaranteed port range, and also ensures that if the user configures a specific port range, spacing, etc, everything agrees.

Documentation also updated

/cc @geekdave 