### PR TITLE
Fix sanitize error when external build id is a number

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -10,7 +10,8 @@ var path = require("path");
 
 // Allow an external build id (eg: from CI system, for example) to be used. If we're not given one,
 // we generate a random build id instead. NOTE: This build id must work as a part of a filename.
-var buildId = argv.external_build_id || "magellan-" + guid();
+// NOTE: The result of this line is that buildId is truthy so toString() should work
+var buildId = (argv.external_build_id || "magellan-" + guid()).toString();
 
 // Create a temporary directory for child build assets like configuration, screenshots, etc.
 var mkdirSync = require("./mkdir_sync");


### PR DESCRIPTION
This fix for `settings.js` ensures that if someone were to pass in an `external_build_id` that yargs or marge provided as a _number_, we `toString()` and sanitize still works (which assumes a string).
 
/cc @archlichking @geekdave 