### PR TITLE
Add time stamps to stdout/stderr stream output

### DIFF
--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -13,6 +13,7 @@ var EventEmitter = require("events").EventEmitter;
 var fs = require("fs");
 var mkdirSync = require("./mkdir_sync");
 var guid = require("./util/guid");
+var logStamp = require("./util/logstamp");
 var sanitizeFilename = require("sanitize-filename");
 
 var sauceBrowsers = require("./sauce/browsers");
@@ -404,11 +405,21 @@ TestRunner.prototype = {
     });
 
     childProcess.stdout.on("data", function (data) {
-      stdout += ("" + data);
+      stdout += ("" + data)
+        .split("\n")
+        .map(function (line) {
+          return clc.greenBright(logStamp()) + " " + line;
+        })
+        .join("\n");
     });
 
     childProcess.stderr.on("data", function (data) {
-      stderr += ("" + data);
+      stderr += ("" + data)
+        .split("\n")
+        .map(function (line) {
+          return clc.greenBright(logStamp()) + " " + line;
+        })
+        .join("\n");
     });
 
     childProcess.on("close", workerClosed);

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -405,21 +405,45 @@ TestRunner.prototype = {
     });
 
     childProcess.stdout.on("data", function (data) {
-      stdout += ("" + data)
-        .split("\n")
-        .map(function (line) {
-          return clc.greenBright(logStamp()) + " " + line;
-        })
-        .join("\n");
+      var text = ("" + data);
+      if (text.trim() !== "") {
+        text = text
+          .split("\n")
+          .filter(function (line) {
+            return line.trim() !== "" || line.indexOf("\n") > -1;
+          })
+          .map(function (line) {
+            return clc.greenBright(logStamp()) + " " + line;
+          })
+          .join("\n");
+
+        if (text.length > 0) {
+          stdout += text + "\n";
+        } else {
+          stdout += "\n";
+        }
+      }
     });
 
     childProcess.stderr.on("data", function (data) {
-      stderr += ("" + data)
-        .split("\n")
-        .map(function (line) {
-          return clc.greenBright(logStamp()) + " " + line;
-        })
-        .join("\n");
+      var text = ("" + data);
+      if (text.trim() !== "") {
+        text = text
+          .split("\n")
+          .filter(function (line) {
+            return line.trim() !== "" || line.indexOf("\n") > -1;
+          })
+          .map(function (line) {
+            return clc.greenBright(logStamp()) + " " + line;
+          })
+          .join("\n");
+
+        if (text.length > 0) {
+          stderr += text + "\n";
+        } else {
+          stderr += "\n";
+        }
+      }
     });
 
     childProcess.on("close", workerClosed);

--- a/src/util/logstamp.js
+++ b/src/util/logstamp.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function () {
+  return new Date().toTimeString().replace(/.*(\d{2}:\d{2}:\d{2}).*/, "$1");
+};


### PR DESCRIPTION
Add time stamps to the output we gather from stdout/stderr of child processes.

![image](https://cloud.githubusercontent.com/assets/12995/15378008/bc093c26-1d14-11e6-9bc3-7f2c089d2b4c.png)

/cc @geekdave @archlichking