### PR TITLE
Blend both stdout streams but with different colors

### DIFF
--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -413,6 +413,7 @@ TestRunner.prototype = {
             return line.trim() !== "" || line.indexOf("\n") > -1;
           })
           .map(function (line) {
+            // NOTE: since this comes from stdout, color the stamps green
             return clc.greenBright(logStamp()) + " " + line;
           })
           .join("\n");
@@ -434,14 +435,15 @@ TestRunner.prototype = {
             return line.trim() !== "" || line.indexOf("\n") > -1;
           })
           .map(function (line) {
-            return clc.greenBright(logStamp()) + " " + line;
+            // NOTE: since this comes from stderr, color the stamps red
+            return clc.redBright(logStamp()) + " " + line;
           })
           .join("\n");
 
         if (text.length > 0) {
-          stderr += text + "\n";
+          stdout += text + "\n";
         } else {
-          stderr += "\n";
+          stdout += "\n";
         }
       }
     });


### PR DESCRIPTION
This PR blends all standard output from `stderr` and `stdout` of child processes into a single stdout. We color our prefixed timestamps red or green according to which stream the text came from so we can still see what was stderr and stdout. This fixes magellan's confusing out-of-order output for `stderr` and `stdout` when showing log output from failed tests.

/cc @archlichking 