### PR TITLE
Add optional reporters list to magellan.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,22 @@ Some custom reporters need to initialize themselves asynchronously before `liste
 
 In the above example, a reporter needs to create a job entry and obtain the id of the job before it can send information about running tests. Magellan will wait until `initialize()` resolves this promise before starting any tests.
 
+Optional Reporter Loading
+=========================
+
+Your project may have reporter modules that you only want to run in certain circumstances, like a CI environment, and you may not want to require them to be installed on a given system (eg: a developer machine). If you want to reference a reporter but still run tests if that reporter is not installed or not found, use `optional_reporters` in `magellan.json`:
+
+```json
+{
+  "reporters": [
+    "./path/to/my/reporter",
+  ],
+  "optional_reporters": [
+    "my_optional_reporter_module"
+  ]
+}
+```
+
 Setup and Teardown
 ==================
 

--- a/bin/magellan
+++ b/bin/magellan
@@ -186,6 +186,14 @@ if (margs.argv.reporters && _.isArray(margs.argv.reporters)) {
   listeners = listeners.concat(margs.argv.reporters.map(loadRelativeModule));
 }
 
+// optional_reporters are modules we want to load only if found. If not found, we
+// still continue initializing Magellan and don't throw any errors or warnings
+if (margs.argv.optional_reporters && _.isArray(margs.argv.optional_reporters)) {
+  listeners = listeners.concat(margs.argv.optional_reporters.map(function (reporterModule) {
+    return loadRelativeModule(reporterModule, true);
+  }));
+}
+
 //
 // Slack integration (enabled if settings exist)
 //

--- a/src/util/load_relative_module.js
+++ b/src/util/load_relative_module.js
@@ -3,7 +3,7 @@
 var path = require("path");
 var clc = require("cli-color");
 
-module.exports = function (mPath) {
+module.exports = function (mPath, moduleIsOptional) {
   var resolvedRequire;
   mPath = mPath.trim();
 
@@ -18,7 +18,7 @@ module.exports = function (mPath) {
     /*eslint global-require: 0*/
     RequiredModule = require(resolvedRequire);
   } catch (e) {
-    if (e.code === "MODULE_NOT_FOUND") {
+    if (e.code === "MODULE_NOT_FOUND" && moduleIsOptional !== true) {
       console.error(clc.redBright("Error loading a module from user configuration."));
       console.error(clc.redBright("Cannot find module: " + resolvedRequire));
       throw new Error(e);


### PR DESCRIPTION
This PR allows for some attached reporter modules to be marked as "optional".

This really means that if we fail to load an **optional** module due to `MODULE_NOT_FOUND`, the error will be ignored, and no unsettling warnings will appear.

/cc @archlichking @geekdave 