### PR TITLE
Fix leaking of sauce connect tunnels and quiet down zombie killing output

### DIFF
--- a/bin/magellan
+++ b/bin/magellan
@@ -43,6 +43,7 @@ var async = require("async");
 var clc = require("cli-color");
 var browsers = require("../src/sauce/browsers");
 var loadRelativeModule = require("../src/util/load_relative_module");
+var processCleanup = require("../src/util/process_cleanup");
 
 var isSauce = margs.argv.sauce ? true : false;
 var isNodeBased = margs.argv.framework && margs.argv.framework.indexOf("mocha") > -1;
@@ -283,16 +284,20 @@ var startSuite = function () {
 
       onSuccess: function () {
         workerAllocator.teardown(function () {
-          deferred.resolve();
+          processCleanup(function () {
+            deferred.resolve();
+          });
         });
       },
 
       onFailure: function (/*failedTests*/) {
         workerAllocator.teardown(function () {
-          // Failed tests are not a failure in Magellan itself, so we pass an empty error
-          // here so that we don't confuse the user. Magellan already outputs a failure
-          // report to the screen in the case of failed tests.
-          deferred.reject(null);
+          processCleanup(function () {
+            // Failed tests are not a failure in Magellan itself, so we pass an empty error
+            // here so that we don't confuse the user. Magellan already outputs a failure
+            // report to the screen in the case of failed tests.
+            deferred.reject(null);
+          });
         });
       }
     });

--- a/src/sauce/worker_allocator.js
+++ b/src/sauce/worker_allocator.js
@@ -264,19 +264,15 @@ SauceWorkerAllocator.prototype.openTunnels = function (callback) {
 SauceWorkerAllocator.prototype.teardownTunnels = function (callback) {
   var self = this;
 
-  var cleanupAndCallback = function () {
-    self.cleanupTunnels(callback);
-  };
-
   var tunnelsOriginallyOpen = this.tunnels.length;
   var tunnelsOpen = this.tunnels.length;
   var tunnelCloseTimeout = (sauceSettings.tunnelTimeout || SECONDS_MINUTE) * SECOND_MS;
 
   var closeTimer = setTimeout(function () {
-    // sometimes, due to network flake, we never get acknowledgement that the tunnel
-    // has been closed.  in such case, we don't want to hang the build indefinitely.
+    // NOTE: We *used to* forcefully clean up stuck tunnels in here, but instead,
+    // we now leave the tunnel processes for process_cleanup to clean up.
     console.log("Timeout reached waiting for tunnels to close... Continuing...");
-    cleanupAndCallback();
+    return callback();
   }, tunnelCloseTimeout);
 
   var tunnelClosed = function () {
@@ -284,7 +280,7 @@ SauceWorkerAllocator.prototype.teardownTunnels = function (callback) {
     if (--tunnelsOpen === 0) {
       console.log("All tunnels closed!  Continuing...");
       clearTimeout(closeTimer);
-      cleanupAndCallback();
+      return callback();
     } else {
       console.log(tunnelsOpen + " of " + tunnelsOriginallyOpen
         + " tunnels still open... waiting...");
@@ -293,24 +289,6 @@ SauceWorkerAllocator.prototype.teardownTunnels = function (callback) {
 
   _.each(self.tunnels, function (tunnelInfo) {
     tunnel.close(tunnelInfo, tunnelClosed);
-  });
-};
-
-SauceWorkerAllocator.prototype.cleanupTunnels = function (callback) {
-  // at this point, all sauce tunnel processes have already been sent the SIGTERM signal,
-  // meaning they've already been "asked politely" to exit.  if any sauce tunnel processes
-  // are still active at this point, we need to forcefully kill them so that we're not
-  // leaving the build environment in a polluted state.
-
-  // NOTE: this may not be Windows compatible
-  var cmd = "pkill -9 -f " + sauceSettings.tunnelId;
-
-  console.log("Cleaning up any remaining sauce connect processes with: " + cmd);
-
-  exec(cmd, {}, function (error, stdout, stderr) {
-    console.log(stdout);
-    console.log(stderr);
-    callback();
   });
 };
 

--- a/src/sauce/worker_allocator.js
+++ b/src/sauce/worker_allocator.js
@@ -5,8 +5,6 @@ var BaseWorkerAllocator = require("../worker_allocator");
 var _ = require("lodash");
 var request = require("request");
 
-var exec = require("child_process").exec;
-
 var sauceSettings = require("./settings");
 var settings = require("../settings");
 var analytics = require("../global_analytics");

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var fork = require("child_process").fork;
-var processCleanup = require("./util/process_cleanup");
 var async = require("async");
 var _ = require("lodash");
 var clc = require("cli-color");
@@ -709,17 +708,12 @@ TestRunner.prototype = {
     var self = this;
 
     setTimeout(function () {
-      // We delay our report to allow bailed builds to clean up before we
-      // outputting our final report to the screen. If processes hang around
-      // for too long, processCleanup() will get rid of them for us.
-      processCleanup(function () {
-        self.summarizeCompletedBuild().then(function () {
-          if (self.failedTests.length === 0) {
-            self.onSuccess();
-          } else {
-            self.onFailure(self.failedTests);
-          }
-        });
+      self.summarizeCompletedBuild().then(function () {
+        if (self.failedTests.length === 0) {
+          self.onSuccess();
+        } else {
+          self.onFailure(self.failedTests);
+        }
       });
     }, FINAL_CLEANUP_DELAY, true);
   },

--- a/src/util/process_cleanup.js
+++ b/src/util/process_cleanup.js
@@ -2,16 +2,19 @@
 
 var treeUtil = require("testarmada-tree-kill");
 var pid = process.pid;
+var settings = require("../settings");
 
 // Max time before we forcefully kill child processes left over after a suite run
 var ZOMBIE_POLLING_MAX_TIME = 15000;
 
 module.exports = function (callback) {
-  console.log("Checking for zombie processes...");
+  if (settings.debug) {
+    console.log("Checking for zombie processes...");
+  }
 
   treeUtil.getZombieChildren(pid, ZOMBIE_POLLING_MAX_TIME, function (zombieChildren) {
     if (zombieChildren.length > 0) {
-      console.log("Magellan giving up waiting for zombie child processes to die. Cleaning up..");
+      console.log("Giving up waiting for zombie child processes to die. Cleaning up..");
 
       var killNextZombie = function () {
         if (zombieChildren.length > 0) {
@@ -26,7 +29,9 @@ module.exports = function (callback) {
 
       return killNextZombie();
     } else {
-      console.log("No zombies found.");
+      if (settings.debug) {
+        console.log("No zombies found.");
+      }
       return callback();
     }
   });


### PR DESCRIPTION
This PR fixes a bug where our zombie killing (`process_cleanup`) code sends `SIGKILL` to friendly sauce connect child processes which we later intend on closing gracefully. Since these sauce connect processes are never allowed to gracefully shut down, the tunnels remain open on Saucelabs, allowing tunnels to pile up. In cases where large numbers of builds happen frequently on a single account, this can easily break Saucelabs' per-account tunnel limit.

I've also quieted down our zombie killing code unless `--debug` is enabled. We still show zombie killing output if zombies are actually found.

#### before/after

Here's the bug in action:

![image](https://cloud.githubusercontent.com/assets/12995/16101039/84975a8e-3317-11e6-8e93-ba850a16203e.png)

In this state, when you sign onto saucelabs afterwards, you can see a lingering tunnel, which indicates the process was abruptly ended with `SIGKILL`. As a result, the tunnel hangs around until the cleanup limit, which is 60 minutes.

In the fixed code, you can see a tunnel process has exited gracefully because it has a non-null exit code

![image](https://cloud.githubusercontent.com/assets/12995/16101072/aef13a20-3317-11e6-9424-8e91dd9fb575.png)

This fix, in particular the fact that the process cleanup is now truly the **very last thing to run** in all of magellan, makes our additional sauce connect `-9` cleanup task redundant as well, so I've removed that too (see this commit: https://github.com/TestArmada/magellan/pull/151/commits/bb6d863f43c8ca97b05e498115b9bcca4d8ead5c )

Thoughts? /cc @geekdave @archlichking 