### PR TITLE
Add support for fast-failed connections in sauce tunnels

### DIFF
--- a/src/sauce/settings.js
+++ b/src/sauce/settings.js
@@ -20,6 +20,7 @@ var config = {
   tunnelTimeout: process.env.SAUCE_TUNNEL_CLOSE_TIMEOUT,
   useTunnels: !!argv.create_tunnels,
   maxTunnels: argv.num_tunnels || 1,
+  fastFailRegexps: process.env.SAUCE_TUNNEL_FAST_FAIL_REGEXPS,
 
   locksServerLocation: argv.locks_server || process.env.LOCKS_SERVER,
   locksOutageTimeout: 1000 * 60 * 5,

--- a/src/sauce/tunnel.js
+++ b/src/sauce/tunnel.js
@@ -69,6 +69,10 @@ module.exports = {
         logfile: logFilePath
       };
 
+      if (settings.fastFailRegexps) {
+        sauceOptions.fastFailRegexps = settings.fastFailRegexps;
+      }
+
       var seleniumPort = options.seleniumPort;
       if (seleniumPort) {
         sauceOptions.port = seleniumPort;


### PR DESCRIPTION
This PR adds support for the sauce connect launcher's "fast fail regexp" list, which allows for connections from sauce VMs to certain hostname patterns to be instantly failed.

/cc @geekdave @archlichking @ThaiWood 