### PR TITLE
Fix unhelpful stack trace error when choosing a browser profile that no longer exists

### DIFF
--- a/bin/magellan
+++ b/bin/magellan
@@ -318,7 +318,14 @@ browsers.initialize(isSauce)
   .then(browserOptions.detectFromCLI.bind({}, margs.argv, isSauce, isNodeBased))
   .then(function (_selectedBrowsers) {
     selectedBrowsers = _selectedBrowsers;
-    if (_selectedBrowsers.length === 0) {
+    if (!_selectedBrowsers) {
+      // If this list comes back completely undefined, it's because we didn't
+      // get anything back from either profile lookup or the saucelabs API, which
+      // likely means we requested a browser that doesn't exist or no longer exists.
+      console.log(clc.redBright("\nError: No matching browsers have been found."
+        + "\nTo see a list of sauce browsers, use the --list_browsers option.\n"));
+      throw new Error("Invalid browser specified for Sauce support");
+    } else if (_selectedBrowsers.length === 0) {
       console.log(clc.redBright("\nError: To use --sauce mode, you need to specify a browser."
         + "\nTo see a list of sauce browsers, use the --list_browsers option.\n"));
       throw new Error("No browser specified for Sauce support");


### PR DESCRIPTION
This PR fixes an unhelpful error we get when selecting a profile name that doesn't exist:

```
01:53:24 Requested profile(s):  t2-safari8
01:53:24 Error initializing Magellan
01:53:24 
01:53:24 Error description:
01:53:24 TypeError: Cannot read property 'length' of undefined
01:53:24 
01:53:24 Error stack trace:
01:53:24 TypeError: Cannot read property 'length' of undefined
01:53:24     at /app/e/node_modules/testarmada-magellan/bin/magellan:321:26
01:53:24     at _fulfilled (/app/e/node_modules/q/q.js:834:54)
01:53:24     at self.promiseDispatch.done (/app/e/node_modules/q/q.js:863:30)
01:53:24     at Promise.promise.promiseDispatch (/app/e/node_modules/q/q.js:796:13)
01:53:24     at /app/e/node_modules/q/q.js:604:44
01:53:24     at runSingle (/app/e/node_modules/q/q.js:137:13)
01:53:24     at flush (/app/e/node_modules/q/q.js:125:13)
01:53:24     at doNTCallback0 (node.js:419:9)
01:53:24     at process._tickCallback (node.js:348:13)
```

/cc @geekdave @archlichking @ThaiWood 