### PR TITLE
Mark process time start in stdout of child processes

### DIFF
--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -285,7 +285,7 @@ TestRunner.prototype = {
     var sentry;
 
     var seleniumSessionId;
-    var stdout = "";
+    var stdout = "{timestamp} : magellan test runner clock-start";
     var stderr = "";
 
     try {

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -285,7 +285,7 @@ TestRunner.prototype = {
     var sentry;
 
     var seleniumSessionId;
-    var stdout = "{timestamp} : magellan test runner clock-start";
+    var stdout = clc.greenBright(logStamp()) + " " + " Magellan child process start\n\n";
     var stderr = "";
 
     try {

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -285,7 +285,7 @@ TestRunner.prototype = {
     var sentry;
 
     var seleniumSessionId;
-    var stdout = clc.greenBright(logStamp()) + " " + " Magellan child process start\n\n";
+    var stdout = clc.greenBright(logStamp()) + " Magellan child process start\n\n";
     var stderr = "";
 
     try {


### PR DESCRIPTION
This PR adds a magellan-injected timestamp into the beginning of every `stdout` string we collect from child processes.

This helps users debug whether their test framework process is taking a very long time to effectively start and begin to consume its `individual test timeout budget`.

For example, **if a test takes 3 minutes to start emitting output to `stdout`**, the feature introduced by this PR will illuminate that problem, because at the beginning of the output we will see the `Magellan child process start` with a timestamp, showing a 3 minute gap between starting the process and getting further output.

/cc @geekdave @archlichking @chaseadamsio @ThaiWood 