### PR TITLE
Update node-slackr

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "guacamole": "^1.2.0",
     "lodash": "^4.6.1",
     "marge": "^1.0.1",
-    "node-slackr": "0.0.4",
+    "node-slackr": "0.1.4",
     "once": "^1.3.1",
     "portscanner": "^1.0.0",
     "pretty-ms": "^1.0.0",

--- a/src/reporters/slack/slack.js
+++ b/src/reporters/slack/slack.js
@@ -35,8 +35,7 @@ Reporter.prototype.initialize = function () {
   var hasAllConfig = true;
   [
     // slack-related
-    "account",
-    "key",
+    "slackURL",
     "channel",
     "username",
     "iconURL",
@@ -50,7 +49,13 @@ Reporter.prototype.initialize = function () {
       console.error("Missing Slack configuration variable: " + key);
     }
   });
-  if (!hasAllConfig) {
+
+  if (this.config.hook || this.config.key) {
+    deferred.reject(new Error(
+      "Error: Slack configuration has changed. \"slackURL\" should be " +
+      "provided instead of \"key\" and \"channel\""
+    ));
+  } else if (!hasAllConfig) {
     deferred.reject(new Error("Error: Missing required Slack configuration variables"));
   }
 
@@ -58,11 +63,12 @@ Reporter.prototype.initialize = function () {
   this.buildDisplayName = this.config.buildDisplayName;
   this.buildURL = this.config.buildURL;
 
-  this.slack = new Slack(this.config.account, this.config.key, {
+  this.slack = new Slack(this.config.slackURL, {
     channel: this.config.channel,
     username: this.config.username,
     /*eslint-disable camelcase*/
     icon_url: this.config.iconURL
+    /*eslint-enable camelcase*/
   });
 
   deferred.resolve();


### PR DESCRIPTION
`node-slackr` is a few versions old and depends on a really old version
of lodash@2. lodash@2 fails to install with [`yarn`](http://yarnpkg.com/)
which makes installing the world substantially faster.

Note that this is a breaking change to the slack configuration.
