### PR TITLE
Throw the error if unable to require module

### DIFF
--- a/src/util/load_relative_module.js
+++ b/src/util/load_relative_module.js
@@ -22,11 +22,15 @@ module.exports = function (mPath, moduleIsOptional, opts) {
   var RequiredModule;
   try {
     /*eslint global-require: 0*/
-    RequiredModule = runOpts.require(resolvedRequire);
+    RequiredModule = require(resolvedRequire);
   } catch (e) {
     if (e.code === "MODULE_NOT_FOUND" && moduleIsOptional !== true) {
-      runOpts.console.error(clc.redBright("Error loading a module from user configuration."));
-      runOpts.console.error(clc.redBright("Cannot find module: " + resolvedRequire));
+      console.error(clc.redBright("Error loading a module from user configuration."));
+      console.error(clc.redBright("Cannot find module: " + resolvedRequire));
+      throw new Error(e);
+    } else if (e.code === "MODULE_NOT_FOUND" && moduleIsOptional === true) {
+      // Do nothing
+    } else {
       throw new Error(e);
     }
   }

--- a/src/util/load_relative_module.js
+++ b/src/util/load_relative_module.js
@@ -22,11 +22,11 @@ module.exports = function (mPath, moduleIsOptional, opts) {
   var RequiredModule;
   try {
     /*eslint global-require: 0*/
-    RequiredModule = require(resolvedRequire);
+    RequiredModule = runOpts.require(resolvedRequire);
   } catch (e) {
     if (e.code === "MODULE_NOT_FOUND" && moduleIsOptional !== true) {
-      console.error(clc.redBright("Error loading a module from user configuration."));
-      console.error(clc.redBright("Cannot find module: " + resolvedRequire));
+      runOpts.console.error(clc.redBright("Error loading a module from user configuration."));
+      runOpts.console.error(clc.redBright("Cannot find module: " + resolvedRequire));
       throw new Error(e);
     } else if (e.code === "MODULE_NOT_FOUND" && moduleIsOptional === true) {
       // Do nothing

--- a/test/utils/load_relative_module.js
+++ b/test/utils/load_relative_module.js
@@ -28,12 +28,29 @@ describe("loadRelativeModule", function () {
     expect(mod).not.to.eql("foo!");
   });
 
-  it("should fail", function () {
+  it("should fail with non-optional module not found", function () {
     var thrown = false;
     try {
       loadRelativeModule("foo.js", false, {
         require: function () {
           throw {code: "MODULE_NOT_FOUND"};
+        },
+        console: {
+          error: function () {}
+        }
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.not.be.null;
+  });
+
+  it("should fail with undefined error code", function () {
+    var thrown = false;
+    try {
+      loadRelativeModule("foo.js", true, {
+        require: function () {
+          throw {code: undefined};
         },
         console: {
           error: function () {}
@@ -56,4 +73,22 @@ describe("loadRelativeModule", function () {
     });
     expect(mod).to.be.null;
   });
+
+  it("should not throw error with optional module not found", function () {
+    var thrown = false;
+    try {
+      loadRelativeModule("foo.js", true, {
+        require: function () {
+          throw {code: "MODULE_NOT_FOUND"};
+        },
+        console: {
+          error: function () {}
+        }
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.be.false;
+  });
+
 });


### PR DESCRIPTION
This makes it easier to debug why magellan won't start. For instance, you'll see
`Error: Error: Module version mismatch. Expected 48, got 46.`

instead of 
`TypeError: Cannot read property 'initialize' of null`

if the node version's don't match.