### PR TITLE
Attach logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "Massively parallel automated testing",
   "main": "src/main",
   "directories": {
@@ -31,7 +31,7 @@
     "integration": "eslint src/** bin/** && ./bin/magellan",
     "lint": "eslint src/** bin/**",
     "coverage": "istanbul cover _mocha -- --recursive",
-    "check-coverage": "istanbul check-coverage --statement 95 --function 95 --branch 90"
+    "check-coverage": "istanbul check-coverage --statement 95 --function 95 --branch 85"
   },
   "dependencies": {
     "acorn": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "integration": "eslint src/** bin/** && ./bin/magellan",
     "lint": "eslint src/** bin/**",
     "coverage": "istanbul cover _mocha -- --recursive",
-    "check-coverage": "istanbul check-coverage --statement 95 --function 95 --branch 85"
+    "check-coverage": "istanbul check-coverage --statement 95 --function 95 --branch 90"
   },
   "dependencies": {
     "acorn": "4.0.4",

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -420,7 +420,8 @@ class TestRunner {
           deferred.resolve({
             error: (code === 0) ? null : "Child test run process exited with code " + code,
             stderr,
-            stdout: stdout + (additionalLog && typeof additionalLog === "string" ? additionalLog : "")
+            stdout: stdout +
+              (additionalLog && typeof additionalLog === "string" ? additionalLog : "")
           });
         });
     });

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -420,7 +420,7 @@ class TestRunner {
           deferred.resolve({
             error: (code === 0) ? null : "Child test run process exited with code " + code,
             stderr,
-            stdout: stdout + additionalLog && typeof additionalLog === "string" ? additionalLog : ""
+            stdout: stdout + (additionalLog && typeof additionalLog === "string" ? additionalLog : "")
           });
         });
     });

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -415,12 +415,12 @@ class TestRunner {
           result: code === 0,
           metadata: testMetadata
         },
-        () => {
+        (additionalLog) => {
           // Resolve the promise
           deferred.resolve({
             error: (code === 0) ? null : "Child test run process exited with code " + code,
             stderr,
-            stdout
+            stdout: stdout + additionalLog && typeof additionalLog === "string" ? additionalLog : ""
           });
         });
     });

--- a/test/test_runner.js
+++ b/test/test_runner.js
@@ -381,6 +381,7 @@ describe("test_runner", () => {
 
     it("successful test without serial", () => {
       optionsMock.serial = false;
+
       const tr = new TestRunner(tests, optionsMock, optsMock);
       tr.onTestComplete(null, successfulTest);
     });
@@ -400,6 +401,7 @@ describe("test_runner", () => {
 
     it("multi tests without serial", () => {
       optionsMock.serial = false;
+      optionsMock.executors["sauce"].summerizeTest = (buildid, metadat, callback) => callback("wt");
       const tr = new TestRunner(tests, optionsMock, optsMock);
       tr.start();
     });
@@ -542,7 +544,7 @@ describe("test_runner", () => {
     it("executor stage error", (done) => {
       const onTestComplete = () => done();
       optionsMock.executors["sauce"].setupTest = (callback) => callback("error");
-
+      
       const tr = new TestRunner(tests, optionsMock, optsMock);
       tr.stageTest(tr.tests[0], onTestComplete);
     });

--- a/test/test_runner.js
+++ b/test/test_runner.js
@@ -381,7 +381,6 @@ describe("test_runner", () => {
 
     it("successful test without serial", () => {
       optionsMock.serial = false;
-
       const tr = new TestRunner(tests, optionsMock, optsMock);
       tr.onTestComplete(null, successfulTest);
     });
@@ -544,7 +543,6 @@ describe("test_runner", () => {
     it("executor stage error", (done) => {
       const onTestComplete = () => done();
       optionsMock.executors["sauce"].setupTest = (callback) => callback("error");
-      
       const tr = new TestRunner(tests, optionsMock, optsMock);
       tr.stageTest(tr.tests[0], onTestComplete);
     });


### PR DESCRIPTION
allow executor to attach additional logs to magellan worker. this is helpful when the additional logs are needed from executor by user, like the replay of test run on vendor's env.