### PR TITLE
[PATCH] Remove duplicate profiles from the test run

### DIFF
--- a/src/profiles.js
+++ b/src/profiles.js
@@ -74,7 +74,11 @@ module.exports = {
 
             _.forEach(requestedProfiles, (requestedProfile) => {
               if (argv.profiles[requestedProfile]) {
-                profiles = _.concat(profiles, argv.profiles[requestedProfile]);
+                // keep only the unique profiles and eliminate duplicates from test run
+                profiles = _.uniqWith(
+                  _.concat(profiles, argv.profiles[requestedProfile]),
+                  _.isEqual
+                );
               } else {
                 notFoundProfiles.push(requestedProfile);
               }

--- a/test/profiles.js
+++ b/test/profiles.js
@@ -105,7 +105,7 @@ describe("handleProfiles", () => {
         });
     });
 
-    it("one profile with five duplicate names should return one unique name", () => {
+    it("one profile with five duplicate browsers should return one unique browser", () => {
       runOpts.margs.argv.profile = "http://some_fake_url#chrome,chrome,chrome,chrome,chrome";
 
       return profile
@@ -131,7 +131,7 @@ describe("handleProfiles", () => {
         });
     });
 
-    it("multiple profiles with one duplicate name should return unique names", () => {
+    it("multiple profiles with one duplicate and one unique browser should return two browsers", () => {
       runOpts.margs.argv.profile = "http://some_fake_url#chrome,firefox,firefox";
 
       return profile
@@ -145,7 +145,7 @@ describe("handleProfiles", () => {
         });
     });
 
-    it("multiple profiles with two duplicate names should return unique names", () => {
+    it("multiple profiles with two duplicate browsers should return two browsers", () => {
       runOpts.margs.argv.profile = "http://some_fake_url#chrome,firefox,firefox,chrome";
 
       return profile
@@ -159,7 +159,7 @@ describe("handleProfiles", () => {
         });
     });
 
-    it("multiple profiles with four duplicate names and one unique should return three unique names", () => {
+    it("multiple profiles with four duplicate and one unique browser should return two browsers", () => {
       runOpts.margs.argv.profile = "http://some_fake_url#firefox,chrome,firefox,firefox,firefox";
 
       return profile
@@ -289,7 +289,6 @@ describe("handleProfiles", () => {
           });
         }
       };
-
 
       return profile
         .detectFromCLI(runOpts)

--- a/test/profiles.js
+++ b/test/profiles.js
@@ -105,6 +105,18 @@ describe("handleProfiles", () => {
         });
     });
 
+    it("one profile with five duplicate names should return one unique name", () => {
+      runOpts.margs.argv.profile = "http://some_fake_url#chrome,chrome,chrome,chrome,chrome";
+
+      return profile
+        .detectFromCLI(runOpts)
+        .then((resolvedprofiles) => {
+          expect(resolvedprofiles.length).to.equal(1);
+          expect(resolvedprofiles[0].browser).to.equal("chrome");
+          expect(resolvedprofiles[0].executor).to.equal("sauce");
+        });
+    });
+
     it("multiple profiles from http", () => {
       runOpts.margs.argv.profile = "http://some_fake_url#chrome,firefox";
 
@@ -115,6 +127,48 @@ describe("handleProfiles", () => {
           expect(resolvedprofiles[0].browser).to.equal("chrome");
           expect(resolvedprofiles[0].executor).to.equal("sauce");
           expect(resolvedprofiles[1].browser).to.equal("firefox");
+          expect(resolvedprofiles[1].executor).to.equal("sauce");
+        });
+    });
+
+    it("multiple profiles with one duplicate name should return unique names", () => {
+      runOpts.margs.argv.profile = "http://some_fake_url#chrome,firefox,firefox";
+
+      return profile
+        .detectFromCLI(runOpts)
+        .then((resolvedprofiles) => {
+          expect(resolvedprofiles.length).to.equal(2);
+          expect(resolvedprofiles[0].browser).to.equal("chrome");
+          expect(resolvedprofiles[0].executor).to.equal("sauce");
+          expect(resolvedprofiles[1].browser).to.equal("firefox");
+          expect(resolvedprofiles[1].executor).to.equal("sauce");
+        });
+    });
+
+    it("multiple profiles with two duplicate names should return unique names", () => {
+      runOpts.margs.argv.profile = "http://some_fake_url#chrome,firefox,firefox,chrome";
+
+      return profile
+        .detectFromCLI(runOpts)
+        .then((resolvedprofiles) => {
+          expect(resolvedprofiles.length).to.equal(2);
+          expect(resolvedprofiles[0].browser).to.equal("chrome");
+          expect(resolvedprofiles[0].executor).to.equal("sauce");
+          expect(resolvedprofiles[1].browser).to.equal("firefox");
+          expect(resolvedprofiles[1].executor).to.equal("sauce");
+        });
+    });
+
+    it("multiple profiles with four duplicate names and one unique should return three unique names", () => {
+      runOpts.margs.argv.profile = "http://some_fake_url#firefox,chrome,firefox,firefox,firefox";
+
+      return profile
+        .detectFromCLI(runOpts)
+        .then((resolvedprofiles) => {
+          expect(resolvedprofiles.length).to.equal(2);
+          expect(resolvedprofiles[0].browser).to.equal("firefox");
+          expect(resolvedprofiles[0].executor).to.equal("sauce");
+          expect(resolvedprofiles[1].browser).to.equal("chrome");
           expect(resolvedprofiles[1].executor).to.equal("sauce");
         });
     });

--- a/test/profiles.js
+++ b/test/profiles.js
@@ -193,6 +193,94 @@ describe("handleProfiles", () => {
         });
     });
 
+    it("two profiles with duplicate profiles should return one unique profile", () => {
+      runOpts.syncRequest = (method, url) => {
+        return {
+          getBody(encoding) {
+            return "{\"profiles\":{\"chrome\":[{\"browser\":\"chrome\", \"resolution\":\"1280x1024\"}],\"chromeV2\":[{\"browser\":\"chrome\", \"resolution\":\"1280x1024\"}],\"firefox\":[{\"browser\":\"firefox\", \"resolution\":\"1280x1024\"}]}}";
+          }
+        };
+      };
+
+      runOpts.margs.argv.profile = "http://some_fake_url#chrome,chromeV2";
+
+      return profile
+        .detectFromCLI(runOpts)
+        .then((resolvedprofiles) => {
+          expect(resolvedprofiles.length).to.equal(1);
+          expect(resolvedprofiles[0].browser).to.equal("chrome");
+          expect(resolvedprofiles[0].resolution).to.equal("1280x1024");
+        });
+    });
+
+    it("two duplicates and one unique profiles should return two unique profiles", () => {
+      runOpts.syncRequest = (method, url) => {
+        return {
+          getBody(encoding) {
+            return "{\"profiles\":{\"chrome\":[{\"browser\":\"chrome\", \"resolution\":\"1280x1024\"}],\"chromeV2\":[{\"browser\":\"chrome\", \"resolution\":\"1280x1024\"}],\"firefox\":[{\"browser\":\"firefox\", \"resolution\":\"1280x1024\"}]}}";
+          }
+        };
+      };
+
+      runOpts.margs.argv.profile = "http://some_fake_url#chrome,chromeV2,firefox";
+
+      return profile
+        .detectFromCLI(runOpts)
+        .then((resolvedprofiles) => {
+          expect(resolvedprofiles.length).to.equal(2);
+          expect(resolvedprofiles[0].browser).to.equal("chrome");
+          expect(resolvedprofiles[0].resolution).to.equal("1280x1024");
+          expect(resolvedprofiles[1].browser).to.equal("firefox");
+          expect(resolvedprofiles[1].resolution).to.equal("1280x1024");
+        });
+    });
+
+    it("two profiles with no duplications should return same two profiles", () => {
+      runOpts.syncRequest = (method, url) => {
+        return {
+          getBody(encoding) {
+            return "{\"profiles\":{\"chrome\":[{\"browser\":\"chrome\", \"resolution\":\"1280x1024\"}],\"chromeV2\":[{\"browser\":\"chrome\", \"resolution\":\"1280x1024\"}],\"firefox\":[{\"browser\":\"firefox\", \"resolution\":\"1280x1024\"}]}}";
+          }
+        };
+      };
+
+      runOpts.margs.argv.profile = "http://some_fake_url#chromeV2,firefox";
+
+      return profile
+        .detectFromCLI(runOpts)
+        .then((resolvedprofiles) => {
+          expect(resolvedprofiles.length).to.equal(2);
+          expect(resolvedprofiles[0].browser).to.equal("chrome");
+          expect(resolvedprofiles[0].resolution).to.equal("1280x1024");
+          expect(resolvedprofiles[1].browser).to.equal("firefox");
+          expect(resolvedprofiles[1].resolution).to.equal("1280x1024");
+        });
+    });
+
+    it("three unique profiles should return same three profiles", () => {
+      runOpts.syncRequest = (method, url) => {
+        return {
+          getBody(encoding) {
+            return "{\"profiles\":{\"chrome\":[{\"browser\":\"chrome\", \"resolution\":\"1280x1024\"}],\"chromeV2\":[{\"browser\":\"chrome\", \"resolution\":\"1200x1024\"}],\"firefox\":[{\"browser\":\"firefox\", \"resolution\":\"1280x1024\"}]}}";
+          }
+        };
+      };
+
+      runOpts.margs.argv.profile = "http://some_fake_url#chrome,chromeV2,firefox";
+
+      return profile
+        .detectFromCLI(runOpts)
+        .then((resolvedprofiles) => {
+          expect(resolvedprofiles.length).to.equal(3);
+          expect(resolvedprofiles[0].browser).to.equal("chrome");
+          expect(resolvedprofiles[0].resolution).to.equal("1280x1024");
+          expect(resolvedprofiles[1].browser).to.equal("chrome");
+          expect(resolvedprofiles[1].resolution).to.equal("1200x1024");
+          expect(resolvedprofiles[2].browser).to.equal("firefox");
+          expect(resolvedprofiles[2].resolution).to.equal("1280x1024");
+        });
+    });
+
     it("no profile matches from url", () => {
       runOpts.margs.argv.profile = "https://some_fake_url#internet";
 


### PR DESCRIPTION
There was an issue in existing logic where duplicate profiles would be selected for the test run if the `--profile` option was used.

For example,

`--profile= http://github.com/browser_profiles.json#browser1,browser2` where we had a `browser1` and `browser2` consisted of:

```
    "browser1": [
      { "browser": "microsoftedge_14_Windows_10_Desktop", "resolution": "1280x1024" },
      { "browser": "safari_10_OS_X_10_11_Desktop", "resolution": "1280x960" },
      { "browser": "chrome_latest_Windows_10_Desktop", "resolution": "1280x1024" },
      { "browser": "IE_11_Windows_10_Desktop", "resolution": "1280x1024" },
      { "browser": "firefox_46_Windows_2012_R2_Desktop", "resolution": "1280x1024" }
    ],

    "browser2": [
      { "browser": "safari_9_OS_X_10_11_Desktop", "resolution": "1280x960" },
      { "browser": "chrome_latest_Windows_10_Desktop", "resolution": "1280x1024" },
      { "browser": "IE_11_Windows_10_Desktop", "resolution": "1280x1024" },
      { "browser": "firefox_46_Windows_2012_R2_Desktop", "resolution": "1280x1024" }
    ],
``` 

*Before fix*, the existing logic would return:
```
[INFO] [Magellan] Running 9 tests in serial mode with [env:microsoftedge_14_Windows_10_Desktop|executor:sauce, env:safari_10_OS_X_10_11_Desktop|executor:sauce, env:chrome_58_Windows_10_Desktop|executor:sauce, env:IE_11_Windows_10_Desktop|executor:sauce, env:firefox_46_Windows_2012_R2_Desktop|executor:sauce, env:safari_9_OS_X_10_11_Desktop|executor:sauce, env:chrome_58_Windows_10_Desktop|executor:sauce, env:IE_11_Windows_10_Desktop|executor:sauce, env:firefox_46_Windows_2012_R2_Desktop|executor:sauce]
```

env:firefox_46_Windows_2012_R2_Desktop, env:chrome_58_Windows_10_Desktop, env:IE_11_Windows_10_Desktop are being duplicated.

This PR eliminates the duplicate profile from the test run, thus running the tests only on the unique browsers/resolution listed in the profiles.

*After fix:*
```
[INFO] [Magellan] Running 6 tests in serial mode with [env:microsoftedge_14_Windows_10_Desktop|executor:sauce, env:safari_10_OS_X_10_11_Desktop|executor:sauce, env:chrome_58_Windows_10_Desktop|executor:sauce, env:IE_11_Windows_10_Desktop|executor:sauce, env:firefox_46_Windows_2012_R2_Desktop|executor:sauce, env:safari_9_OS_X_10_11_Desktop|executor:sauce]
```

🎉 No more duplicates (reduces test time as well) 🎉 

/cc @Maciek416 @archlichking 