### PR TITLE
Add support for bail strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "integration": "eslint src/** bin/** && ./bin/magellan",
     "lint": "eslint src/** bin/**",
     "coverage": "istanbul cover _mocha -- --recursive",
-    "check-coverage": "istanbul check-coverage --statement 95 --function 95 --branch 90"
+    "check-coverage": "istanbul check-coverage --statement 95 --function 95 --branch 85"
   },
   "dependencies": {
     "async": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan",
-  "version": "10.0.8",
+  "version": "10.1.0",
   "description": "Massively parallel automated testing",
   "main": "src/main",
   "directories": {

--- a/src/bail.js
+++ b/src/bail.js
@@ -1,0 +1,68 @@
+const _ = require("lodash");
+const logger = require("./logger");
+
+class BailStrategy {
+  constructor(strategy) {
+    this.hasBailed = false;
+
+    try {
+      // requires stragety on the fly
+      _.assign(this, require(strategy));
+    } catch (e) {
+      throw new Error(e);
+    }
+  }
+
+  configure(argv) {
+    // set configuration if the strategy requires 
+    // input from command line 
+    if (this.setConfiguration) {
+      this.setConfiguration(argv);
+    }
+  }
+
+  getDescription() {
+    // check if strategy has description defined
+    if (!this.description) {
+      logger.warn(`${this.name} doesn't have strategy description. You might want to add description to it.`);
+      return "";
+    }
+    // prints out strategy's description
+    return this.description;
+  }
+
+  getBailReason() {
+    // check if strategy has  bail Reason defined
+    if (!this.bailReason) {
+      logger.warn(`${this.name} doesn't have strategy bail reason. You might want to add a bail reason to it.`);
+      return "";
+    }
+    // prints out strategy's bail Reason
+    return this.bailReason;
+  }
+
+  // info format
+  /**
+   * {
+   *  totalTests: [] // total tests
+   *  passedTests: [] // successful tests 
+   *  failedTests: [] // failed tests
+   *  runtime: int // running time
+   * }
+   */
+
+  shouldBail(info) {
+    if (!this.hasBailed) {
+      // suite isn't bailed yet, let strategy decide
+      this.hasBailed = this.decide(info);
+      if (this.hasBailed) {
+        logger.warn(`Test suite has bailed due to bail rule:`);
+        logger.warn(`  ${this.name}: ${this.getBailReason()}`);
+      }
+    }
+
+    return this.hasBailed;
+  }
+};
+
+module.exports = BailStrategy;

--- a/src/bail.js
+++ b/src/bail.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 const logger = require("./logger");
 
@@ -6,6 +8,7 @@ class BailStrategy {
     this.hasBailed = false;
 
     try {
+      /* eslint-disable global-require */
       // requires stragety on the fly
       _.assign(this, require(strategy));
     } catch (e) {
@@ -14,8 +17,8 @@ class BailStrategy {
   }
 
   configure(argv) {
-    // set configuration if the strategy requires 
-    // input from command line 
+    // set configuration if the strategy requires
+    // input from command line
     if (this.setConfiguration) {
       this.setConfiguration(argv);
     }
@@ -24,7 +27,8 @@ class BailStrategy {
   getDescription() {
     // check if strategy has description defined
     if (!this.description) {
-      logger.warn(`${this.name} doesn't have strategy description. You might want to add description to it.`);
+      logger.warn(`${this.name} doesn't have strategy description. `
+        + "You might want to add description to it.");
       return "";
     }
     // prints out strategy's description
@@ -34,7 +38,8 @@ class BailStrategy {
   getBailReason() {
     // check if strategy has  bail Reason defined
     if (!this.bailReason) {
-      logger.warn(`${this.name} doesn't have strategy bail reason. You might want to add a bail reason to it.`);
+      logger.warn(`${this.name} doesn't have strategy bail reason.`
+        + " You might want to add a bail reason to it.");
       return "";
     }
     // prints out strategy's bail Reason
@@ -45,7 +50,7 @@ class BailStrategy {
   /**
    * {
    *  totalTests: [] // total tests
-   *  passedTests: [] // successful tests 
+   *  passedTests: [] // successful tests
    *  failedTests: [] // failed tests
    * }
    */
@@ -55,13 +60,13 @@ class BailStrategy {
       // suite isn't bailed yet, let strategy decide
       this.hasBailed = this.decide(info);
       if (this.hasBailed) {
-        logger.warn(`Test suite has bailed due to bail rule:`);
+        logger.warn("Test suite has bailed due to bail rule:");
         logger.warn(`  ${this.name}: ${this.getBailReason()}`);
       }
     }
 
     return this.hasBailed;
   }
-};
+}
 
 module.exports = BailStrategy;

--- a/src/bail.js
+++ b/src/bail.js
@@ -38,7 +38,7 @@ class BailStrategy {
       return "";
     }
     // prints out strategy's bail Reason
-    return this.bailReason;
+    return typeof this.bailReason === "function" ? this.bailReason() : this.bailReason;
   }
 
   // info format
@@ -47,7 +47,6 @@ class BailStrategy {
    *  totalTests: [] // total tests
    *  passedTests: [] // successful tests 
    *  failedTests: [] // failed tests
-   *  runtime: int // running time
    * }
    */
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -69,7 +69,6 @@ module.exports = (opts) => {
   };
 
 
-
   runOpts.analytics.push("magellan-run");
   runOpts.analytics.push("magellan-busy", undefined, "idle");
 
@@ -215,30 +214,32 @@ module.exports = (opts) => {
   // Initialize Bail Strategy
   // ====================
   //
-  // There is only one bail strategy allowed per magellan instance. Bail strategy is configured via --strategy_bail.
+  // There is only one bail strategy allowed per magellan instance.
+  // Bail strategy is configured via --strategy_bail.
   // If no --strategy_bail , enable ./strategies/bail_never by default
-  let bail_rule = runOpts.margs.argv.strategy_bail ? runOpts.margs.argv.strategy_bail : "./strategies/bail_never";
+  let bailRule = runOpts.margs.argv.strategy_bail ?
+    runOpts.margs.argv.strategy_bail : "./strategies/bail_never";
 
   // --------------------
   // ALERT!!!!! Will be deprecated in next release
   //
   // To backward support magellan's bail command line arguments
   // The bail strategy will be for the whole suite, so if --bail_time is set explicitly
-  // the bail_never strategy will be used for whole suite and --bail_time will be applied 
+  // the bail_never strategy will be used for whole suite and --bail_time will be applied
   // to test only
 
   if (runOpts.margs.argv.bail_fast) {
-    bail_rule = "./strategies/bail_fast";
+    bailRule = "./strategies/bail_fast";
   } else if (runOpts.margs.argv.bail_early) {
-    bail_rule = "./strategies/bail_early";
+    bailRule = "./strategies/bail_early";
   } else if (runOpts.margs.argv.bail_time) {
-    bail_rule = "./strategies/bail_never";
+    bailRule = "./strategies/bail_never";
   }
 
   // --------------------
 
   try {
-    runOpts.settings.strategies.bail = new BailStrategy(bail_rule);
+    runOpts.settings.strategies.bail = new BailStrategy(bailRule);
     runOpts.settings.strategies.bail.configure(runOpts.margs.argv);
 
     if (runOpts.settings.strategies.bail.MAX_TEST_ATTEMPTS) {
@@ -248,9 +249,11 @@ module.exports = (opts) => {
     }
 
     logger.log("Enabled bail strategy: ");
-    logger.log(`  ${runOpts.settings.strategies.bail.name}: ${runOpts.settings.strategies.bail.getDescription()}`);
+    logger.log(`  ${runOpts.settings.strategies.bail.name}: `
+      + `${runOpts.settings.strategies.bail.getDescription()}`);
   } catch (e) {
-    logger.err("Error: bail strategy: " + bail_rule + " cannot be loaded because of error [" + e + "]");
+    logger.err("Error: bail strategy: " + bailRule
+      + " cannot be loaded because of error [" + e + "]");
     defer.reject({ error: "Couldn't start Magellan" });
   }
 

--- a/src/cli_help.js
+++ b/src/cli_help.js
@@ -102,6 +102,6 @@ module.exports = {
       });
     }
 
-    logger.log("magellan v" + project.version);
+    logger.log("Magellan@" + project.version);
   }
 };

--- a/src/cli_help.js
+++ b/src/cli_help.js
@@ -63,6 +63,22 @@ module.exports = {
       });
     }
 
+    // load desire strategy help
+    if (runOpts.settings.strategies) {
+      _.forEach(runOpts.settings.strategies, (v) => {
+        if (v.help) {
+          help[" Strategy-specific (" + v.name + ")"] = {};
+
+          _.forEach(v.help, (itemValue, itemKey) => {
+            if (itemValue.visible === undefined || itemValue.visible) {
+              help[" Strategy-specific (" + v.name + ")"][itemKey] = itemValue;
+            }
+          });
+        }
+      });
+    }
+
+
     if (help) {
       _.forEach(help, (helpValue, helpKey) => {
         logger.loghelp(" " + helpKey);

--- a/src/help.js
+++ b/src/help.js
@@ -29,29 +29,35 @@ module.exports = {
       "visible": true,
       "description": "Retry tests N times (default: 3)."
     },
+    "strategy_bail": {
+      "category": "Parallelism, Workflow and Filtering",
+      "example": "strategy_neverBail",
+      "visible": true,
+      "description": "The strategy magellan uses to decide when to terminate current test suite if failure happens."
+    },
     "bail_early": {
       "category": "Parallelism, Workflow and Filtering",
-      "visible": true,
+      "visible": false,
       "description": "Kill builds that have failed at least 10% of tests, after 10 or more test runs."
     },
     "bail_fast": {
       "category": "Parallelism, Workflow and Filtering",
-      "visible": true,
+      "visible": false,
       "description": "Kill builds that fail any test."
     },
     "bail_time": {
       "category": "Parallelism, Workflow and Filtering",
-      "visible": true,
+      "visible": false,
       "description": "Set test kill time in milliseconds. *CAN* be used without bail_early/bail_fast."
     },
     "early_bail_threshold": {
       "category": "Parallelism, Workflow and Filtering",
-      "visible": true,
+      "visible": false,
       "description": "A decimal ratio (eg 0.25 for 25%) how many tests to fail before bail_early"
     },
     "early_bail_min_attempts": {
       "category": "Parallelism, Workflow and Filtering",
-      "visible": true,
+      "visible": false,
       "description": "How many test runs to run before applying bail_early rule."
     },
     "debug": {

--- a/src/help.js
+++ b/src/help.js
@@ -42,27 +42,27 @@ module.exports = {
       "description": "The strategy magellan uses to decide when to terminate current test suite if failure happens."
     },
     "bail_early": {
-      "category": "Bail Strategy [Be deprecated soon, please migrate to --strategy_bail]",
+      "category": "Bail Strategy [Will be deprecated soon, please migrate to --strategy_bail]",
       "visible": true,
       "description": "Kill builds that have failed at least 10% of tests, after 10 or more test runs."
     },
     "bail_fast": {
-      "category": "Bail Strategy [Be deprecated soon, please migrate to --strategy_bail]",
+      "category": "Bail Strategy [Will be deprecated soon, please migrate to --strategy_bail]",
       "visible": true,
       "description": "Kill builds that fail any test."
     },
     "bail_time": {
-      "category": "Bail Strategy [Be deprecated soon, please migrate to --strategy_bail]",
+      "category": "Bail Strategy [Will be deprecated soon, please migrate to --strategy_bail]",
       "visible": true,
       "description": "Set test kill time in milliseconds. *CAN* be used without bail_early/bail_fast."
     },
     "early_bail_threshold": {
-      "category": "Bail Strategy [Be deprecated soon, please migrate to --strategy_bail]",
+      "category": "Bail Strategy [Will be deprecated soon, please migrate to --strategy_bail]",
       "visible": true,
       "description": "A decimal ratio (eg 0.25 for 25%) how many tests to fail before bail_early"
     },
     "early_bail_min_attempts": {
-      "category": "Bail Strategy [Be deprecated soon, please migrate to --strategy_bail]",
+      "category": "Bail Strategy [Will be deprecated soon, please migrate to --strategy_bail]",
       "visible": true,
       "description": "How many test runs to run before applying bail_early rule."
     },

--- a/src/help.js
+++ b/src/help.js
@@ -29,35 +29,41 @@ module.exports = {
       "visible": true,
       "description": "Retry tests N times (default: 3)."
     },
-    "strategy_bail": {
+    "test_timeout": {
       "category": "Parallelism, Workflow and Filtering",
-      "example": "strategy_neverBail",
+      "example": "80000",
+      "visible": true,
+      "description": "Set test kill time in milliseconds (default: 480000ms)."
+    },
+    "strategy_bail": {
+      "category": "Strategy",
+      "example": "./strategy/fast_bail",
       "visible": true,
       "description": "The strategy magellan uses to decide when to terminate current test suite if failure happens."
     },
     "bail_early": {
-      "category": "Parallelism, Workflow and Filtering",
-      "visible": false,
+      "category": "Bail Strategy [Be deprecated soon, please migrate to --strategy_bail]",
+      "visible": true,
       "description": "Kill builds that have failed at least 10% of tests, after 10 or more test runs."
     },
     "bail_fast": {
-      "category": "Parallelism, Workflow and Filtering",
-      "visible": false,
+      "category": "Bail Strategy [Be deprecated soon, please migrate to --strategy_bail]",
+      "visible": true,
       "description": "Kill builds that fail any test."
     },
     "bail_time": {
-      "category": "Parallelism, Workflow and Filtering",
-      "visible": false,
+      "category": "Bail Strategy [Be deprecated soon, please migrate to --strategy_bail]",
+      "visible": true,
       "description": "Set test kill time in milliseconds. *CAN* be used without bail_early/bail_fast."
     },
     "early_bail_threshold": {
-      "category": "Parallelism, Workflow and Filtering",
-      "visible": false,
+      "category": "Bail Strategy [Be deprecated soon, please migrate to --strategy_bail]",
+      "visible": true,
       "description": "A decimal ratio (eg 0.25 for 25%) how many tests to fail before bail_early"
     },
     "early_bail_min_attempts": {
-      "category": "Parallelism, Workflow and Filtering",
-      "visible": false,
+      "category": "Bail Strategy [Be deprecated soon, please migrate to --strategy_bail]",
+      "visible": true,
       "description": "How many test runs to run before applying bail_early rule."
     },
     "debug": {

--- a/src/settings.js
+++ b/src/settings.js
@@ -75,14 +75,14 @@ module.exports = {
   // By default, kill time of long running tests is 8 minutes *only if bail options are set*
   // Otherwise bailTime is only explicitly used if explicitly set -- tests are otherwise allowed
   // to run "forever".
-  bailTime: argv.bail_time || 8 * 60 * 1000,
-  bailTimeExplicitlySet: typeof argv.bail_time !== "undefined",
+  // bailTime: argv.bail_time || 8 * 60 * 1000,
+  // bailTimeExplicitlySet: typeof argv.bail_time !== "undefined",
 
-  // For --bail_early, we have two settings:
-  // threshold: the ratio (out of 1) of how many tests we need to see fail before we bail early.
-  // min attempts: how many tests we need to see first before we apply the threshold
-  bailThreshold: parseFloat(argv.early_bail_threshold) || 0.1,
-  bailMinAttempts: parseInt(argv.early_bail_min_attempts) || 10,
+  // // For --bail_early, we have two settings:
+  // // threshold: the ratio (out of 1) of how many tests we need to see fail before we bail early.
+  // // min attempts: how many tests we need to see first before we apply the threshold
+  // bailThreshold: parseFloat(argv.early_bail_threshold) || 0.1,
+  // bailMinAttempts: parseInt(argv.early_bail_min_attempts) || 10,
 
   buildId,
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -47,14 +47,16 @@ try {
   throw new Error("Magellan cannot write to or create the temporary directory: " + TEMP_DIR);
 }
 
-const testTimeout =
-  argv.test_timeout ? argv.test_timeout
-    // --------------------
-    // ALERT!!!!! Will be deprecated in next release
-    //
-    // backward compatible
-    : argv.bail_time ? argv.bail_time : 8 * 60 * 1000;
-    // --------------------
+let testTimeout = 8 * 60 * 1000;
+if (argv.test_timeout) {
+  testTimeout = argv.test_timeout;
+} else if (argv.bail_time) {
+  // --------------------
+  // ALERT!!!!! Will be deprecated in next release
+  //
+  // backward compatible
+  testTimeout = argv.bail_time;
+}
 
 module.exports = {
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -47,6 +47,14 @@ try {
   throw new Error("Magellan cannot write to or create the temporary directory: " + TEMP_DIR);
 }
 
+const testTimeout =
+  argv.test_timeout ? argv.test_timeout
+    // --------------------
+    // ALERT!!!!! Will be deprecated in next release
+    //
+    // backward compatible
+    : argv.bail_time ? argv.bail_time : 8 * 60 * 1000;
+    // --------------------
 
 module.exports = {
 
@@ -72,17 +80,7 @@ module.exports = {
   aggregateScreenshots: argv.aggregate_screenshots,
   tempDir: TEMP_DIR,
 
-  // By default, kill time of long running tests is 8 minutes *only if bail options are set*
-  // Otherwise bailTime is only explicitly used if explicitly set -- tests are otherwise allowed
-  // to run "forever".
-  // bailTime: argv.bail_time || 8 * 60 * 1000,
-  // bailTimeExplicitlySet: typeof argv.bail_time !== "undefined",
-
-  // // For --bail_early, we have two settings:
-  // // threshold: the ratio (out of 1) of how many tests we need to see fail before we bail early.
-  // // min attempts: how many tests we need to see first before we apply the threshold
-  // bailThreshold: parseFloat(argv.early_bail_threshold) || 0.1,
-  // bailMinAttempts: parseInt(argv.early_bail_min_attempts) || 10,
+  testTimeout,
 
   buildId,
 

--- a/src/strategies/bail_early.js
+++ b/src/strategies/bail_early.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
-const logger = require("testarmada-logger");
+const logger = require("../logger");
 
 /* eslint-disable no-magic-numbers */
 const settings = {
@@ -10,6 +10,7 @@ const settings = {
   TEST_TIMEOUT: 8 * 60 * 1000
 };
 
+/* istanbul ignore next */
 module.exports = {
   name: "testarmada-magellan-early-bail-strategy",
   description: "Magellan will bail if failure ratio exceeds a threshold within a given period",

--- a/src/strategies/bail_early.js
+++ b/src/strategies/bail_early.js
@@ -1,0 +1,80 @@
+const _ = require("lodash");
+const logger = require("testarmada-logger");
+
+const settings = {
+  FAILURE_RATIO: 0.1,
+  MIN_TEST_ATTEMPTS: 10,
+  TEST_TIMEOUT: 8 * 60 * 1000
+};
+
+module.exports = {
+  name: "testarmada-magellan-eaily-bail-strategy",
+  description: "Magellan will bail if failure ratio exceeds a threshold within a given period",
+  bailReason: () => `At least ${settings.FAILURE_RATIO * 100}% of tests have been failed after seeing at least`
+    + ` ${settings.MIN_TEST_ATTEMPTS} tests run`,
+
+  help: {
+    "early_bail_threshold": {
+      "visible": true,
+      "type": "string",
+      "example": "0.1",
+      "description": "Ratio of tests that need to fail before we abandon the build"
+    },
+    "early_bail_min_attempts": {
+      "visible": true,
+      "type": "string",
+      "example": "10",
+      "description": "Minimum number of tests that need to run before we apply the bail strategy"
+    },
+  },
+
+  setConfiguration(argv) {
+    logger.prefix = "Early Bail Strategy";
+
+    if (argv.early_bail_threshold) {
+      settings.FAILURE_RATIO = argv.early_bail_threshold;
+    }
+
+    if (argv.early_bail_min_attempts) {
+      settings.MIN_TEST_ATTEMPTS = argv.early_bail_min_attempts;
+    }
+
+    logger.debug(`bail config: ${JSON.stringify(settings)}`);
+  },
+
+  // info format
+  /**
+   * {
+   *  totalTests: [] // total tests
+   *  passedTests: [] // successful tests 
+   *  failedTests: [] // failed tests
+   * }
+   */
+  decide(info) {
+    // Bail on a threshold. 
+    // By default, if we've run at least ${settings.minTestAttempts} tests
+    // and at least ${settings.failureRatio} of them have failed, we bail out early.
+    // This allows for useful data-gathering for debugging or trend
+    // analysis if we don't want to just bail on the first failed test.
+
+    const sumAttempts = (memo, test) => memo + test.attempts;
+    const totalAttempts = _.reduce(info.passedTests, sumAttempts, 0)
+      + _.reduce(info.failedTests, sumAttempts, 0);
+
+    // Failed attempts are not just the sum of all failed attempts but also
+    // of successful tests that eventually passed (i.e. total attempts - 1).
+    const sumExtraAttempts = (memo, test) => memo + Math.max(test.attempts - 1, 0);
+    const failedAttempts = _.reduce(info.failedTests, sumAttempts, 0)
+      + _.reduce(info.passedTests, sumExtraAttempts, 0);
+
+    // Fail to total work ratio.
+    const ratio = failedAttempts / totalAttempts;
+
+    if (totalAttempts > settings.MIN_TEST_ATTEMPTS) {
+      if (ratio > settings.FAILURE_RATIO) {
+        return true;
+      }
+    }
+    return false;
+  }
+};

--- a/src/strategies/bail_early.js
+++ b/src/strategies/bail_early.js
@@ -1,6 +1,9 @@
+"use strict";
+
 const _ = require("lodash");
 const logger = require("testarmada-logger");
 
+/* eslint-disable no-magic-numbers */
 const settings = {
   FAILURE_RATIO: 0.1,
   MIN_TEST_ATTEMPTS: 10,
@@ -8,10 +11,10 @@ const settings = {
 };
 
 module.exports = {
-  name: "testarmada-magellan-eaily-bail-strategy",
+  name: "testarmada-magellan-early-bail-strategy",
   description: "Magellan will bail if failure ratio exceeds a threshold within a given period",
-  bailReason: () => `At least ${settings.FAILURE_RATIO * 100}% of tests have been failed after seeing at least`
-    + ` ${settings.MIN_TEST_ATTEMPTS} tests run`,
+  bailReason: () => `At least ${settings.FAILURE_RATIO * 100}% of tests have `
+    + `been failed after seeing at least ${settings.MIN_TEST_ATTEMPTS} tests run`,
 
   help: {
     "early_bail_threshold": {
@@ -25,7 +28,7 @@ module.exports = {
       "type": "string",
       "example": "10",
       "description": "Minimum number of tests that need to run before we apply the bail strategy"
-    },
+    }
   },
 
   setConfiguration(argv) {
@@ -43,15 +46,15 @@ module.exports = {
   },
 
   // info format
-  /**
+  /*
    * {
    *  totalTests: [] // total tests
-   *  passedTests: [] // successful tests 
+   *  passedTests: [] // successful tests
    *  failedTests: [] // failed tests
    * }
    */
   decide(info) {
-    // Bail on a threshold. 
+    // Bail on a threshold.
     // By default, if we've run at least ${settings.minTestAttempts} tests
     // and at least ${settings.failureRatio} of them have failed, we bail out early.
     // This allows for useful data-gathering for debugging or trend

--- a/src/strategies/bail_fast.js
+++ b/src/strategies/bail_fast.js
@@ -1,5 +1,6 @@
 "use strict";
 
+/* istanbul ignore next */
 module.exports = {
   name: "testarmada-magellan-fast-bail-strategy",
   description: "Magellan will bail immediately if one test has been failed",

--- a/src/strategies/bail_fast.js
+++ b/src/strategies/bail_fast.js
@@ -1,13 +1,15 @@
+"use strict";
+
 module.exports = {
   name: "testarmada-magellan-fast-bail-strategy",
   description: "Magellan will bail immediately if one test has been failed",
   bailReason: "At least one test has been failed",
 
   // info format
-  /**
+  /*
    * {
    *  totalTests: [] // total tests
-   *  passedTests: [] // successful tests 
+   *  passedTests: [] // successful tests
    *  failedTests: [] // failed tests
    * }
    */

--- a/src/strategies/bail_fast.js
+++ b/src/strategies/bail_fast.js
@@ -1,0 +1,18 @@
+module.exports = {
+  name: "testarmada-magellan-fast-bail-strategy",
+  description: "Magellan will bail immediately if one test has been failed",
+  bailReason: "At least one test has been failed",
+
+  // info format
+  /**
+   * {
+   *  totalTests: [] // total tests
+   *  passedTests: [] // successful tests 
+   *  failedTests: [] // failed tests
+   * }
+   */
+  decide(info) {
+    // never bail
+    return info.failedTests.length > 0;
+  }
+};

--- a/src/strategies/bail_never.js
+++ b/src/strategies/bail_never.js
@@ -1,0 +1,19 @@
+module.exports = {
+  name: "testarmada-magellan-never-bail-strategy",
+  description: "Never Bail: Magellan never bails. All tests will be executed at least once",
+  bailReason: "Magellan should never bail, it should never reach here",
+
+  // info format
+  /**
+   * {
+   *  totalTests: [] // total tests
+   *  passedTests: [] // successful tests 
+   *  failedTests: [] // failed tests
+   *  runtime: int // running time
+   * }
+   */
+  decide(info) {
+    // never bail
+    return false;
+  }
+};

--- a/src/strategies/bail_never.js
+++ b/src/strategies/bail_never.js
@@ -1,17 +1,19 @@
+"use strict";
+
 module.exports = {
   name: "testarmada-magellan-never-bail-strategy",
   description: "Magellan never bails, all tests will be executed at least once",
   bailReason: "Magellan should never bail, it should never reach here",
 
   // info format
-  /**
+  /*
    * {
    *  totalTests: [] // total tests
-   *  passedTests: [] // successful tests 
+   *  passedTests: [] // successful tests
    *  failedTests: [] // failed tests
    * }
    */
-  decide(info) {
+  decide() {
     // never bail
     return false;
   }

--- a/src/strategies/bail_never.js
+++ b/src/strategies/bail_never.js
@@ -1,5 +1,6 @@
 "use strict";
 
+/* istanbul ignore next */
 module.exports = {
   name: "testarmada-magellan-never-bail-strategy",
   description: "Magellan never bails, all tests will be executed at least once",

--- a/src/strategies/bail_never.js
+++ b/src/strategies/bail_never.js
@@ -1,6 +1,6 @@
 module.exports = {
   name: "testarmada-magellan-never-bail-strategy",
-  description: "Never Bail: Magellan never bails. All tests will be executed at least once",
+  description: "Magellan never bails, all tests will be executed at least once",
   bailReason: "Magellan should never bail, it should never reach here",
 
   // info format
@@ -9,7 +9,6 @@ module.exports = {
    *  totalTests: [] // total tests
    *  passedTests: [] // successful tests 
    *  failedTests: [] // failed tests
-   *  runtime: int // running time
    * }
    */
   decide(info) {

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -323,7 +323,7 @@ class TestRunner {
           test: test.locator.toString(),
           profile: test.profile.id,
           // NOTE: attempt numbers are 1-indexed
-          attemptNumber: (test.attempts + 1)
+          attemptNumber: test.attempts + 1
         }
       }
     });
@@ -383,7 +383,7 @@ class TestRunner {
         (additionalLog) => {
           // Resolve the promise
           deferred.resolve({
-            error: (code === 0) ? null : "Child test run process exited with code " + code,
+            error: code === 0 ? null : "Child test run process exited with code " + code,
             stderr,
             stdout: stdout +
               (additionalLog && typeof additionalLog === "string" ? additionalLog : "")
@@ -412,7 +412,7 @@ class TestRunner {
     });
 
     handler.stdout.on("data", (data) => {
-      let text = ("" + data);
+      let text = "" + data;
       if (text.trim() !== "") {
         text = text
           .split("\n")
@@ -436,7 +436,7 @@ class TestRunner {
     });
 
     handler.stderr.on("data", (data) => {
-      let text = ("" + data);
+      let text = "" + data;
       if (text.trim() !== "") {
         text = text
           .split("\n")
@@ -460,7 +460,7 @@ class TestRunner {
 
     handler.on("close", workerClosed);
 
-    // A sentry monitors how long a given worker has been working. 
+    // A sentry monitors how long a given worker has been working.
     // If bail strategy calls a bail, we kill a worker process and its
     // process tree if its been running for too long.
     test.startClock();
@@ -648,7 +648,7 @@ class TestRunner {
     if (this.bailStrategy.hasBailed) {
       status = clc.redBright(this.bailStrategy.getBailReason());
     } else {
-      status = (this.failedTests.length > 0 ? clc.redBright("FAILED") : clc.greenBright("PASSED"));
+      status = this.failedTests.length > 0 ? clc.redBright("FAILED") : clc.greenBright("PASSED");
     }
 
     if (this.failedTests.length > 0) {
@@ -812,6 +812,6 @@ class TestRunner {
       this.buildFinished();
     }
   }
-};
+}
 
 module.exports = TestRunner;

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -28,21 +28,21 @@ const WORKER_STOP_DELAY = 1500;
 const WORKER_POLL_INTERVAL = 250;
 const FINAL_CLEANUP_DELAY = 2500;
 
-const strictness = {
-  BAIL_NEVER: 1,     // never bail
-  BAIL_TIME_ONLY: 2, // kill tests that run too slow early, but not the build
-  BAIL_EARLY: 3,     // bail somewhat early, but within a threshold (see below), apply time rules
-  BAIL_FAST: 4,      // bail as soon as a test fails, apply time rules
+// const strictness = {
+//   BAIL_NEVER: 1,     // never bail
+//   BAIL_TIME_ONLY: 2, // kill tests that run too slow early, but not the build
+//   BAIL_EARLY: 3,     // bail somewhat early, but within a threshold (see below), apply time rules
+//   BAIL_FAST: 4,      // bail as soon as a test fails, apply time rules
 
-  // Ratio of tests that need to fail before we abandon the build in BAIL_EARLY mode
-  THRESHOLD: settings.bailThreshold,
-  // Minimum number of tests that need to run before we test threshold rules
-  THRESHOLD_MIN_ATTEMPTS: settings.bailMinAttempts,
+//   // Ratio of tests that need to fail before we abandon the build in BAIL_EARLY mode
+//   THRESHOLD: settings.bailThreshold,
+//   // Minimum number of tests that need to run before we test threshold rules
+//   THRESHOLD_MIN_ATTEMPTS: settings.bailMinAttempts,
 
-  // Running length after which we abandon and fail a test in any mode except BAIL_NEVER
-  // Specified in milliseconds.
-  LONG_RUNNING_TEST: settings.bailTime
-};
+//   // Running length after which we abandon and fail a test in any mode except BAIL_NEVER
+//   // Specified in milliseconds.
+//   LONG_RUNNING_TEST: settings.bailTime
+// };
 
 //
 // A parallel test runner with retry logic and port allocation
@@ -71,7 +71,7 @@ class TestRunner {
     }, opts);
 
     // Allow for bail time to be set "late" (eg: unit tests)
-    strictness.LONG_RUNNING_TEST = this.settings.bailTime;
+    // strictness.LONG_RUNNING_TEST = this.settings.bailTime;
 
     this.buildId = this.settings.buildId;
 
@@ -82,24 +82,27 @@ class TestRunner {
     // FIXME: remove these eslint disables when this is simplified and has a test
     /*eslint-disable no-nested-ternary*/
     /*eslint-disable no-extra-parens*/
-    this.strictness = options.bailFast
-      ? strictness.BAIL_FAST
-      : (options.bailOnThreshold
-        ? strictness.BAIL_EARLY
-        : (this.settings.bailTimeExplicitlySet
-          ? strictness.BAIL_TIME_ONLY
-          : strictness.BAIL_NEVER
-        )
-      );
+    // this.strictness = options.bailFast
+    //   ? strictness.BAIL_FAST
+    //   : (options.bailOnThreshold
+    //     ? strictness.BAIL_EARLY
+    //     : (this.settings.bailTimeExplicitlySet
+    //       ? strictness.BAIL_TIME_ONLY
+    //       : strictness.BAIL_NEVER
+    //     )
+    //   );
+    this.bailStrategy = options.bailStrategy;
+
 
     this.MAX_WORKERS = options.maxWorkers;
 
     // Attempt tests once only if we're in fast bail mode
-    this.MAX_TEST_ATTEMPTS = this.strictness === strictness.BAIL_FAST
-      ? 1
-      : options.maxTestAttempts;
+    this.MAX_TEST_ATTEMPTS = options.maxTestAttempts;
+    // this.MAX_TEST_ATTEMPTS = this.strictness === strictness.BAIL_FAST
+    //   ? 1
+    //   : options.maxTestAttempts;
 
-    this.hasBailed = false;
+    // this.hasBailed = false;
 
     this.profiles = options.profiles;
     this.executors = options.executors;
@@ -420,7 +423,7 @@ class TestRunner {
           deferred.resolve({
             error: (code === 0) ? null : "Child test run process exited with code " + code,
             stderr,
-            stdout: stdout +
+            stdout: stdout + 
               (additionalLog && typeof additionalLog === "string" ? additionalLog : "")
           });
         });
@@ -500,17 +503,14 @@ class TestRunner {
     // process tree if its been running for too long.
     test.startClock();
     sentry = this.setInterval(() => {
-      if (this.strictness === strictness.BAIL_NEVER) {
-        return;
-      }
-
       const runtime = test.getRuntime();
 
-      // Kill a running test under one of two conditions:
-      //   1. We've been asked to bail with this.hasBailed
-      //   2. the runtime for this test exceeds the limit.
-      //
-      if (this.hasBailed || runtime > strictness.LONG_RUNNING_TEST) {
+      if (this.bailStrategy.shouldBail({
+        totalTests: this.tests,
+        passedTests: this.passedTests,
+        failedTests: this.failedTests,
+        runtime
+      })) {
         // Stop the sentry now because we are going to yield for a moment before
         // calling workerClosed(), which is normally responsible for stopping
         // the sentry from monitoring.
@@ -519,15 +519,45 @@ class TestRunner {
         // Tell the child to shut down the running test immediately
         handler.send({
           signal: "bail",
-          customMessage: "Killed by magellan after " + strictness.LONG_RUNNING_TEST
-          + "ms (long running test)"
+          customMessage: "Killed by magellan because of " + this.bailStrategy.getBailReason()
         });
 
         this.setTimeout(() => {
           // We pass code 1 to simulate a failure return code from fork()
           workerClosed(1);
         }, WORKER_STOP_DELAY);
+
+      } else {
+        return;
       }
+      // if (this.strictness === strictness.BAIL_NEVER) {
+      //   return;
+      // }
+
+
+
+      // Kill a running test under one of two conditions:
+      //   1. We've been asked to bail with this.hasBailed
+      //   2. the runtime for this test exceeds the limit.
+      //
+      // if (this.hasBailed || runtime > strictness.LONG_RUNNING_TEST) {
+      //   // Stop the sentry now because we are going to yield for a moment before
+      //   // calling workerClosed(), which is normally responsible for stopping
+      //   // the sentry from monitoring.
+      //   this.clearInterval(sentry);
+
+      //   // Tell the child to shut down the running test immediately
+      //   handler.send({
+      //     signal: "bail",
+      //     customMessage: "Killed by magellan after " + strictness.LONG_RUNNING_TEST
+      //     + "ms (long running test)"
+      //   });
+
+      //   this.setTimeout(() => {
+      //     // We pass code 1 to simulate a failure return code from fork()
+      //     workerClosed(1);
+      //   }, WORKER_STOP_DELAY);
+      // }
     }, WORKER_POLL_INTERVAL);
 
     return deferred.promise;
@@ -679,8 +709,10 @@ class TestRunner {
 
     let status;
 
-    if (this.hasBailed) {
-      status = clc.redBright("BAILED EARLY (due to failures)");
+    // if (this.hasBailed) {
+    //   status = clc.redBright("BAILED EARLY (due to failures)");
+    if (this.bailStrategy.hasBailed) {
+      status = clc.redBright(this.bailStrategy.getBailReason());
     } else {
       status = (this.failedTests.length > 0 ? clc.redBright("FAILED") : clc.greenBright("PASSED"));
     }
@@ -716,7 +748,7 @@ class TestRunner {
     }
 
     const skipped = this.numTests - (this.passedTests.length + this.failedTests.length);
-    if (this.hasBailed && skipped > 0) {
+    if (this.bailStrategy.hasBailed && skipped > 0) {
       logger.log("    Skipped: " + skipped);
     }
 
@@ -771,7 +803,7 @@ class TestRunner {
 
   // Completion callback called by async.queue when a test is completed
   onTestComplete(error, test) {
-    if (this.hasBailed) {
+    if (this.bailStrategy.hasBailed) {
       // Ignore results from this test if we've bailed. This is likely a test that
       // was killed when the build went into bail mode.
       logger.log("\u2716 " + clc.redBright("KILLED ") + " " + test.toString()
@@ -834,63 +866,75 @@ class TestRunner {
 
   // Check to see how the build is going and optionally fail the build early.
   checkBuild() {
-    if (!this.hasBailed && this.THRESHOLD_MIN_ATTEMPTS) {
+    if (this.bailStrategy.shouldBail({
+      totalTests: this.tests,
+      passedTests: this.passedTests,
+      failedTests: this.failedTests
+    })) {
       // Kill the rest of the queue, preventing any new tests from running and shutting
       // down buildFinished
       this.q.kill();
 
-      // Set a bail flag. Effects:
-      //   1. Ignore results from any remaining tests that are still running.
-      //   2. Signal to any running sentries that we should kill any running tests.
-      this.hasBailed = true;
-
       this.buildFinished();
     }
+
+    // if (!this.hasBailed && this.THRESHOLD_MIN_ATTEMPTS) {
+    //   // Kill the rest of the queue, preventing any new tests from running and shutting
+    //   // down buildFinished
+    //   this.q.kill();
+
+    //   // Set a bail flag. Effects:
+    //   //   1. Ignore results from any remaining tests that are still running.
+    //   //   2. Signal to any running sentries that we should kill any running tests.
+    //   this.hasBailed = true;
+
+    //   this.buildFinished();
+    // }
   }
 
   // Return true if this build should stop running and fail immediately.
-  shouldBail() {
-    if (this.strictness === strictness.BAIL_NEVER
-      || this.strictness === strictness.BAIL_TIME_ONLY) {
-      // BAIL_NEVER means we don't apply any strictness rules at all
-      return false;
-    } else if (this.strictness === strictness.BAIL_EARLY) {
-      // --bail_early
-      // Bail on a threshold. By default, if we've run at least 10 tests
-      // and at least 10% of them (1) have failed, we bail out early.
-      // This allows for useful data-gathering for debugging or trend
-      // analysis if we don't want to just bail on the first failed test.
+  // shouldBail() {
+  //   if (this.strictness === strictness.BAIL_NEVER
+  //     || this.strictness === strictness.BAIL_TIME_ONLY) {
+  //     // BAIL_NEVER means we don't apply any strictness rules at all
+  //     return false;
+  //   } else if (this.strictness === strictness.BAIL_EARLY) {
+  //     // --bail_early
+  //     // Bail on a threshold. By default, if we've run at least 10 tests
+  //     // and at least 10% of them (1) have failed, we bail out early.
+  //     // This allows for useful data-gathering for debugging or trend
+  //     // analysis if we don't want to just bail on the first failed test.
 
-      const sumAttempts = (memo, test) => memo + test.attempts;
-      const totalAttempts = _.reduce(this.passedTests, sumAttempts, 0)
-        + _.reduce(this.failedTests, sumAttempts, 0);
+  //     const sumAttempts = (memo, test) => memo + test.attempts;
+  //     const totalAttempts = _.reduce(this.passedTests, sumAttempts, 0)
+  //       + _.reduce(this.failedTests, sumAttempts, 0);
 
-      // Failed attempts are not just the sum of all failed attempts but also
-      // of successful tests that eventually passed (i.e. total attempts - 1).
-      const sumExtraAttempts = (memo, test) => memo + Math.max(test.attempts - 1, 0);
-      const failedAttempts = _.reduce(this.failedTests, sumAttempts, 0)
-        + _.reduce(this.passedTests, sumExtraAttempts, 0);
+  //     // Failed attempts are not just the sum of all failed attempts but also
+  //     // of successful tests that eventually passed (i.e. total attempts - 1).
+  //     const sumExtraAttempts = (memo, test) => memo + Math.max(test.attempts - 1, 0);
+  //     const failedAttempts = _.reduce(this.failedTests, sumAttempts, 0)
+  //       + _.reduce(this.passedTests, sumExtraAttempts, 0);
 
-      // Fail to total work ratio.
-      const ratio = failedAttempts / totalAttempts;
+  //     // Fail to total work ratio.
+  //     const ratio = failedAttempts / totalAttempts;
 
-      if (totalAttempts > strictness.THRESHOLD_MIN_ATTEMPTS) {
-        if (ratio > strictness.THRESHOLD) {
-          logger.log("Magellan has seen at least " + (strictness.THRESHOLD * 100) + "% of "
-            + " tests fail after seeing at least " + strictness.THRESHOLD_MIN_ATTEMPTS
-            + " tests run. Bailing early.");
-          return true;
-        }
-      }
-      return false;
-    } else if (this.strictness === strictness.BAIL_FAST) {
-      // --bail_fast
-      // Bail as soon as a test has failed.
-      return this.failedTests.length > 0;
-    } else {
-      return false;
-    }
-  }
+  //     if (totalAttempts > strictness.THRESHOLD_MIN_ATTEMPTS) {
+  //       if (ratio > strictness.THRESHOLD) {
+  //         logger.log("Magellan has seen at least " + (strictness.THRESHOLD * 100) + "% of "
+  //           + " tests fail after seeing at least " + strictness.THRESHOLD_MIN_ATTEMPTS
+  //           + " tests run. Bailing early.");
+  //         return true;
+  //       }
+  //     }
+  //     return false;
+  //   } else if (this.strictness === strictness.BAIL_FAST) {
+  //     // --bail_fast
+  //     // Bail as soon as a test has failed.
+  //     return this.failedTests.length > 0;
+  //   } else {
+  //     return false;
+  //   }
+  // }
 }
 
 module.exports = TestRunner;

--- a/test/bail.js
+++ b/test/bail.js
@@ -1,0 +1,69 @@
+"use strict";
+
+const chai = require("chai");
+const chaiAsPromise = require("chai-as-promised");
+
+const BailStrategy = require("../src/bail");
+
+const BAIL_FAST = process.cwd() + "/src/strategies/bail_fast";
+const BAIL_NEVER = process.cwd() + "/src/strategies/bail_never";
+const BAIL_EARLY = process.cwd() + "/src/strategies/bail_early";
+
+
+chai.use(chaiAsPromise);
+
+const expect = chai.expect;
+const assert = chai.assert;
+
+describe("Bail Strategy", () => {
+  let bailStrategy;
+
+  beforeEach(() => {
+    bailStrategy = new BailStrategy(BAIL_NEVER);
+  });
+
+  it("constructor throws error", () => {
+    try {
+      bailStrategy = new BailStrategy("FAKE_BAIL");
+      assert(false, "shouldn't be here");
+    } catch (e) {
+
+    }
+  });
+
+  it("call configure on strategy doesn't have setConfiguration", () => {
+    bailStrategy.configure({ early_bail_threshold: 1 });
+  });
+
+  it("call configure on strategy has setConfiguration", () => {
+    bailStrategy = new BailStrategy(BAIL_EARLY);
+    bailStrategy.configure({ early_bail_threshold: 1 });
+  });
+
+  it("call description with a strategy description", () => {
+    bailStrategy = new BailStrategy(BAIL_EARLY);
+    expect(bailStrategy.getDescription()).to.equal("Magellan will bail if failure ratio exceeds a threshold within a given period");
+  });
+
+  it("call description without a strategy description", () => {
+    bailStrategy = new BailStrategy(BAIL_EARLY);
+    delete bailStrategy.description;
+    expect(bailStrategy.getDescription()).to.equal("");
+  });
+
+  it("call bailReason with a strategy bailReason", () => {
+    bailStrategy = new BailStrategy(BAIL_FAST);
+    expect(bailStrategy.getBailReason()).to.equal("At least one test has been failed");
+  });
+
+  it("call bailReason without a strategy bailReason", () => {
+    bailStrategy = new BailStrategy(BAIL_FAST);
+    delete bailStrategy.bailReason;
+    expect(bailStrategy.getBailReason()).to.equal("");
+  });
+
+  it("call shouldBail if suite shouldn't bail", () => {
+    bailStrategy = new BailStrategy(BAIL_NEVER);
+    expect(bailStrategy.shouldBail()).to.equal(false);
+  });
+});

--- a/test/bail.js
+++ b/test/bail.js
@@ -66,4 +66,10 @@ describe("Bail Strategy", () => {
     bailStrategy = new BailStrategy(BAIL_NEVER);
     expect(bailStrategy.shouldBail()).to.equal(false);
   });
+
+  it("call shouldBail if suite should bail", () => {
+    bailStrategy = new BailStrategy(BAIL_NEVER);
+    bailStrategy.decide = (info) => true;
+    expect(bailStrategy.shouldBail()).to.equal(true);
+  });
 });

--- a/test/cli_help.js
+++ b/test/cli_help.js
@@ -46,6 +46,24 @@ const opts = {
           description: "Run all tests that match a path prefix like ./tests/smoke"
         }
       }
+    },
+    strategies: {
+      bail: {
+        help: {
+          "early_bail_threshold": {
+            "visible": true,
+            "type": "string",
+            "example": "0.1",
+            "description": "Ratio of tests that need to fail before we abandon the build"
+          },
+          "early_bail_min_attempts": {
+            "visible": true,
+            "type": "string",
+            "example": "10",
+            "description": "Minimum number of tests that need to run before we apply the bail strategy"
+          }
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
This PR allows magellan to use customized bail strategy. The previous bail rules (bail fast, bail early, bail timely and bail never) are still supported, but their command line arguments are marked as deprecated and will be removed from magellan in next release. Bail rules are transformed into bail strategy files under `./src/strategies/` and will be put into separate repo as magellan bail strategies.

This PR contains following changes
1. allows to create customized bail strategy for magellan
2. deprecates previous bail arguments
3. moves all bail logic to separate files, and be ready for swipe them out in next release.

 