### PR TITLE
Show passed test results if debug == true

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -58,6 +58,7 @@ module.exports = (opts) => {
   //   runOpts.margs.argv.framework.indexOf("mocha") > -1;
 
   const debug = runOpts.margs.argv.debug || false;
+  const showPassedTests = runOpts.margs.argv.show_passed_tests || false;
   const useSerialMode = runOpts.margs.argv.serial;
   let MAX_TEST_ATTEMPTS = parseInt(runOpts.margs.argv.max_test_attempts) || 3;
   let targetProfiles;
@@ -408,6 +409,7 @@ module.exports = (opts) => {
 
           const testRunner = new runOpts.TestRunner(tests, {
             debug,
+            showPassedTests,
 
             maxWorkers: MAX_WORKERS,
 

--- a/src/help.js
+++ b/src/help.js
@@ -71,6 +71,11 @@ module.exports = {
       "visible": true,
       "description": "Enable debugging magellan messages (dev mode)."
     },
+    "show_passed_tests": {
+      "category": "Parallelism, Workflow and Filtering",
+      "visible": true,
+      "description": "Show passed tests output."
+    },
     "config": {
       "category": "Configuration",
       "visible": true,

--- a/src/settings.js
+++ b/src/settings.js
@@ -76,6 +76,7 @@ module.exports = {
   environment: env,
 
   debug: argv.debug,
+  showPassedTests: argv.show_passed_tests,
 
   gatherTrends: argv.gather_trends,
 

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -37,6 +37,7 @@ const FINAL_CLEANUP_DELAY = 2500;
 //   getEnvironment      - function(worker, test) that returns a key value object to use as the
 //                         process environment
 //   debug               - true/false flag for magellan debugging mode
+//   showPassedTests     - true/false flag for magellan show passed tests mode
 //   onSuccess           - function() callback
 //   onFailure           - function(failedTests) callback
 // opts: testing options
@@ -69,6 +70,7 @@ class TestRunner {
     this.profiles = options.profiles;
     this.executors = options.executors;
     this.debug = options.debug;
+    this.showPassedTests = options.showPassedTests;
 
     this.serial = options.serial || false;
 
@@ -617,17 +619,16 @@ class TestRunner {
     }
   }
 
-  logPassedTests: function () {
-    console.log(clc.greenBright("\n============= Passed Tests:  =============\n"));
+  logPassedTests() {
+    logger.log(clc.greenBright("============= Passed Tests:  ============="));
 
-    this.passedTests.forEach(function (passedTest) {
-      console.log("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -"
-        + " - - - - - - - - - - - - - - - ");
-      console.log("Passed Test: " + passedTest.toString());
-      console.log(" # attempts: " + passedTest.attempts);
-      console.log("     output: ");
-      console.log(passedTest.stdout);
-      console.log(passedTest.stderr);
+    this.passedTests.forEach((passedTest) => {
+      logger.log("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
+      logger.log("Passed Test: " + passedTest.toString());
+      logger.log(" # attempts: " + passedTest.attempts);
+      logger.log("     output: ");
+      logger.log(passedTest.stdout);
+      logger.log(passedTest.stderr);
     });
   },
 
@@ -653,7 +654,7 @@ class TestRunner {
 
     this.gatherTrends();
 
-    if (this.debug) {
+    if (this.showPassedTests) {
       if (this.passedTests.length > 0) {
         this.logPassedTests();
       }

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -630,7 +630,7 @@ class TestRunner {
       logger.log(passedTest.stdout);
       logger.log(passedTest.stderr);
     });
-  },
+  }
 
   logFailedTests() {
     logger.log(clc.redBright("============= Failed Tests:  ============="));

--- a/src/test_runner.js
+++ b/src/test_runner.js
@@ -617,6 +617,20 @@ class TestRunner {
     }
   }
 
+  logPassedTests: function () {
+    console.log(clc.greenBright("\n============= Passed Tests:  =============\n"));
+
+    this.passedTests.forEach(function (passedTest) {
+      console.log("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -"
+        + " - - - - - - - - - - - - - - - ");
+      console.log("Passed Test: " + passedTest.toString());
+      console.log(" # attempts: " + passedTest.attempts);
+      console.log("     output: ");
+      console.log(passedTest.stdout);
+      console.log(passedTest.stderr);
+    });
+  },
+
   logFailedTests() {
     logger.log(clc.redBright("============= Failed Tests:  ============="));
 
@@ -638,6 +652,12 @@ class TestRunner {
     const retryMetrics = {};
 
     this.gatherTrends();
+
+    if (this.debug) {
+      if (this.passedTests.length > 0) {
+        this.logPassedTests();
+      }
+    }
 
     if (this.failedTests.length > 0) {
       this.logFailedTests();

--- a/src/worker_allocator.js
+++ b/src/worker_allocator.js
@@ -18,6 +18,7 @@ class Allocator {
       checkPorts: portUtil.checkPorts,
       getNextPort: portUtil.getNextPort,
       debug: settings.debug
+      showPassedTests: settings.showPassedTests // Is this needed ?
     }, opts);
 
     logger.debug("Worker Allocator starting.");

--- a/src/worker_allocator.js
+++ b/src/worker_allocator.js
@@ -17,7 +17,7 @@ class Allocator {
       setTimeout,
       checkPorts: portUtil.checkPorts,
       getNextPort: portUtil.getNextPort,
-      debug: settings.debug
+      debug: settings.debug,
       showPassedTests: settings.showPassedTests // Is this needed ?
     }, opts);
 


### PR DESCRIPTION
I think it could be helpful to be able to see the passed tests logs as well.

I was between creating a new method, `logPassedTests`, or updating `logFailedTests` to `logTests` and having it be passed in test results.

I also didn't know if I should create a new flag, or use the existing debug flag. I went with the existing debug flag since it was easier.

I made the passedTests logs appear first, so the failed tests were easier to see (since they'd be at the bottom of the console).