### PR TITLE
Update plugin docs to existing api

### DIFF
--- a/doc/FRAMEWORK_PLUGINS.md
+++ b/doc/FRAMEWORK_PLUGINS.md
@@ -39,7 +39,7 @@ The `iterator` property of the plugin is a function that returns an array of tes
 
 Each object should represent exactly one test.
 
-Magellan doesn't care how the object is structured, except that the object should expose a `filename` 
+Magellan does not care how the object is structured, except that the object should expose a `filename` 
 property with the path to the test and should implement a `toString()` method so that Magellan can 
 display a human-readable name for the test on the screen.
 

--- a/doc/FRAMEWORK_PLUGINS.md
+++ b/doc/FRAMEWORK_PLUGINS.md
@@ -137,18 +137,18 @@ We recommend adding at least `--tags`, `--group`, and `--test` to preserve user'
 filters: {
 
   // Adds --tags=xxxx command line switch
-  tags: function (tags, testLocator) {
-    /* return true if testLocator satisfies tags from --tags=t1,t2,.. */
+  tags: function (tests, tags) {
+    /* return a filtered list of tests matching --tags=t1,t2,.. */
   },
 
   // Adds --group=xxxx command line switch
-  group: function (prefix, testLocator) {
-    /* return true if testLocator satisfies prefix from --group=a/b/c*/
+  group: function (tests, prefix) {
+    /* return a filtered list of tests matching --group=a/b/c*/
   },
 
   // Adds --test=xxxx command line switch
-  test: function (testidentity, testLocator) {
-    /* return true if testLocator is the same as --test=path-or-name */
+  test: function (tests, testpath) {
+    /* return a filtered list of tests matching --test=path-or-name */
   }
 },
 ```

--- a/doc/FRAMEWORK_PLUGINS.md
+++ b/doc/FRAMEWORK_PLUGINS.md
@@ -39,8 +39,9 @@ The `iterator` property of the plugin is a function that returns an array of tes
 
 Each object should represent exactly one test.
 
-Magellan doesn't care how the object is structured, except that the object should implement a
-`toString()` method so that Magellan can display a human-readable name for the test on the screen.
+Magellan doesn't care how the object is structured, except that the object should expose a `filename` 
+property with the path to the test and should implement a `toString()` method so that Magellan can 
+display a human-readable name for the test on the screen.
 
 If your test framework makes human-readable test names available and you are able to parse or query
 these with your plugin, it's recommended that your `toString()` implementation returns a name as
@@ -50,6 +51,8 @@ opposed to a filename. For example:
 > var t = new Locator("/path/to/test.js", "Should add integers and return an integer");
 > t.toString()
 "Should add integers and return an integer"
+> t.filename
+"/path/to/test.js"
 ```
 
 #### TestRun Class


### PR DESCRIPTION
There were a few things in the plugin doc that don't seem current.

`iterator` requires tests to also implement a `filename` property that `magellan` uses to print found tests. This could also be moved to use `toString` but I figured a doc update was simpler for now.
https://github.com/TestArmada/magellan/blob/189dd6001e8eb2696caf69e6d987b3104cbd8d33/src/cli.js#L335

`filters` receive an array of tests (from `iterator`) as the first parameter and the filter as the second parameter (see [magellan-nightwatch-plugin](https://github.com/TestArmada/magellan-nightwatch-plugin/blob/22428883264cc42042ebad163b508599ce3f619c/lib/group_filter.js#L10)) and must return a list of tests to run.