### PR TITLE
Updated logic to check every port in the range, and move to the next set

### DIFF
--- a/src/util/port_util.js
+++ b/src/util/port_util.js
@@ -38,7 +38,7 @@ const util = {
       // check all the ports in the range. If fail, move to next set
       const startPort = util.getNextPort();
       const ports = [];
-      for(let i=startPort;i<startPort + settings.BASE_PORT_SPACING; i++){
+      for (let i = startPort; i < startPort + settings.BASE_PORT_SPACING; i++) {
         ports.push(i);
       }
       checkPorts(ports, (result) => {

--- a/src/util/port_util.js
+++ b/src/util/port_util.js
@@ -35,7 +35,13 @@ const util = {
     let attempts = 0;
 
     const acquire = () => {
-      checkPorts([util.getNextPort()], (result) => {
+      // check all the ports in the range. If fail, move to next set
+      const startPort = util.getNextPort();
+      const ports = [];
+      for(let i=startPort;i<startPort + settings.BASE_PORT_SPACING; i++){
+        ports.push(i);
+      }
+      checkPorts(ports, (result) => {
         if (result[0].available) {
           return callback(null, result[0].port);
         } else {

--- a/test/utils/port_util.test.js
+++ b/test/utils/port_util.test.js
@@ -59,3 +59,44 @@ test('should throw exception after maximum retries', () => {
   expect(spy.called).toEqual(true);
   expect(spy.args[0][0].message).toEqual('Gave up looking for an available port after 100 attempts.');
 });
+
+test('should acquire next port if any port is not available', () => {
+
+  // can't reset port_util.portCursor, so we just have to start where it left off
+  expect(portUtil.getNextPort()).toEqual(12327)
+
+  checkPorts.mockImplementation((arr, cb) => {
+    // second port not available
+    arr[1] === 12331 ? cb([{
+      port: arr[0],
+      available: false
+    }]) : cb([{
+      port: arr[0],
+      available: true
+    }]);
+  });
+
+  const spy = sinon.spy();
+  portUtil.acquirePort(spy);
+  expect(spy.called).toEqual(true);
+  expect(spy.args[0]).toEqual([null, 12333]);
+
+  // can't reset port_util.portCursor, so we just have to start where it left off
+  expect(portUtil.getNextPort()).toEqual(12336)
+
+  checkPorts.mockImplementation((arr, cb) => {
+    // third port not available
+    arr[1] === 12340 ? cb([{
+      port: arr[0],
+      available: false
+    }]) : cb([{
+      port: arr[0],
+      available: true
+    }]);
+  });
+
+  const spy2 = sinon.spy();
+  portUtil.acquirePort(spy2);
+  expect(spy2.called).toEqual(true);
+  expect(spy2.args[0]).toEqual([null, 12342]);
+});


### PR DESCRIPTION
Changed logic to check all the ports in between current port and next port, calculated by BASE_PORT_SPACING.

So if BASE_PORT_START is 12000 and BASE_PORT_SPACING is 3, it will check ports 12000, 12001, and 12002. If any of those ports are not available, it will check 12003 through 12005, and so on.