### PR TITLE
Do not abort on uncaught exception

### DIFF
--- a/bin/magellan
+++ b/bin/magellan
@@ -12,7 +12,7 @@ const settings = require("../src/settings");
 const constants = require("../src/constants");
 
 process.on('uncaughtException', function (error) {
-  console.error("Magellan uncaughtException", error);
+  console.trace("Magellan uncaughtException", error);
 });
 
 co(function *() {

--- a/bin/magellan
+++ b/bin/magellan
@@ -11,7 +11,7 @@ const cli = require("../src/cli");
 const settings = require("../src/settings");
 const constants = require("../src/constants");
 
-process.on('uncaughtException', function (error) {
+process.on("uncaughtException", function (error) {
   console.trace("Magellan uncaughtException", error);
 });
 

--- a/bin/magellan
+++ b/bin/magellan
@@ -11,6 +11,10 @@ const cli = require("../src/cli");
 const settings = require("../src/settings");
 const constants = require("../src/constants");
 
+process.on('uncaughtException', function (error) {
+  console.error("Magellan uncaughtException", error);
+});
+
 co(function *() {
   cli.version();
 


### PR DESCRIPTION
The following anywhere in the process will cause magellan to abort and exit:
require('fs').createReadStream( '/tmp/' );

This prevents that.