### PR TITLE
bump-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan",
-  "version": "11.0.8",
+  "version": "11.0.10",
   "description": "Massively parallel automated testing",
   "main": "src/main",
   "directories": {


### PR DESCRIPTION
Need to bump the version - doing a release

`11.0.9` is already released, so going to `11.0.10`

cheers!