### PR TITLE
Use strictly pipes in ChildProcess, also this fixes a bug with the reporters getting unfiltered stdout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan",
-  "version": "11.0.10",
+  "version": "11.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6196,9 +6196,9 @@
       }
     },
     "stream-slic3r": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-slic3r/-/stream-slic3r-1.0.0.tgz",
-      "integrity": "sha512-m9puwM+gmgwM6xnF3QcfhZ6TW3LeAW3jm2LtIStCyxhrInOBaxaghMVXDhJa4YF2xo97BH6w63jWuB01rgqZKA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-slic3r/-/stream-slic3r-1.0.1.tgz",
+      "integrity": "sha512-je5WJ19ehdWToJEs2XVnaZoukj3O8Oy/pDhQOyNF1Ug5RrBLz8jOXGPV6wd6vCOraPAfOGr3xOwtHBtRqlTaAw=="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan",
-  "version": "11.0.11",
+  "version": "11.0.12",
   "description": "Massively parallel automated testing",
   "main": "src/main",
   "directories": {
@@ -46,7 +46,7 @@
     "request": "^2.55.0",
     "sanitize-filename": "^1.5.3",
     "slugify": "^1.0.2",
-    "stream-slic3r": "^1.0.0",
+    "stream-slic3r": "^1.0.1",
     "sync-request": "^4.0.1",
     "testarmada-magellan-local-executor": "^2.0.0",
     "testarmada-tree-kill": "^2.0.0",

--- a/test/utils/child_process.test.js
+++ b/test/utils/child_process.test.js
@@ -2,17 +2,13 @@
 
 const child_process = require('child_process');
 const ChildProcess = require('../../src/util/childProcess');
+const { PassThrough } = require('stream');
 
 jest.mock('child_process');
 
-const handler = {
+const newHandler = () => ({
   removeAllListeners: () => { },
-  stdout: {
-    on: () => { },
-    removeAllListeners: () => { },
-    unpipe: () => { },
-    pipe: () => { }
-  },
+  stdout: new PassThrough(),
   stderr: {
     on: () => { },
     removeAllListeners: () => { },
@@ -20,21 +16,21 @@ const handler = {
   },
   send: (msg) => { },
   on: (msg, cb) => cb(msg)
-};
+});
 
 describe('Child process', () => {
 
   test('should construct new object', () => {
-    const cp = new ChildProcess(handler);
+    const cp = new ChildProcess(newHandler());
   });
 
   test('should enable debug message', () => {
-    const cp = new ChildProcess(handler);
+    const cp = new ChildProcess(newHandler());
     cp.enableDebugMsg();
   });
 
   test('should enable onMessage', (done) => {
-    const cp = new ChildProcess(handler);
+    const cp = new ChildProcess(newHandler());
 
     cp.onMessage((msg) => {
       expect(msg).toEqual('message');
@@ -43,7 +39,7 @@ describe('Child process', () => {
   });
 
   test('should enable onClose', (done) => {
-    const cp = new ChildProcess(handler);
+    const cp = new ChildProcess(newHandler());
 
     cp.onClose((msg) => {
       expect(msg).toEqual('close');
@@ -52,57 +48,72 @@ describe('Child process', () => {
   });
 
   test('should enable send', () => {
-    const cp = new ChildProcess(handler);
+    const cp = new ChildProcess(newHandler());
     cp.send('fake message');
   });
 
   test('should emit message', () => {
-    const cp = new ChildProcess(handler);
+    const cp = new ChildProcess(newHandler());
     cp.emitMessage('fake message');
   });
 
   test('should tearDown', () => {
-    const cp = new ChildProcess(handler);
+    const cp = new ChildProcess(newHandler());
     cp.teardown();
   });
 
-  test('should append data to stdout', () => {
-    const cp = new ChildProcess(handler);
+  test('should append data to stdout', (done) => {
+    const cp = new ChildProcess(newHandler());
 
-    cp.onDataCallback('WARN fake data');
-    cp.onDataCallback('WARN real data');
-    cp.onDataCallback('');
+    cp.handler.stdout.write('WARN fake data');
+    cp.handler.stdout.end('WARN real data');
 
-    expect(cp.stdout).toContain('fake data');
-    expect(cp.stdout).toContain('real data');
+    // wait for the write to flow thru the slicer and filter transforms
+    setTimeout(() => {
+      expect(cp.stdout).toContain('fake data');
+      expect(cp.stdout).toContain('real data');
+      done();
+    }, 0)
+
   });
 
-  test('should add context to error message', () => {
-    const cp = new ChildProcess(handler);
+  test('should add context to error message', (done) => {
+    const cp = new ChildProcess(newHandler());
 
-    cp.onDataCallback('ERROR Connection refused! Is selenium server started?')
+    cp.handler.stdout.end('ERROR Connection refused! Is selenium server started?');
 
-    expect(cp.stdout).toContain('Connection refused! Is selenium server started?')    
-    expect(cp.stdout).toContain(`If running on saucelabs, perhaps you're out of capacity and should TRY RUN AGAIN LATER :)`);
+    // wait for the write to flow thru the slicer and filter transforms
+    setTimeout(() => {
+      expect(cp.stdout).toContain('Connection refused! Is selenium server started?')    
+      expect(cp.stdout).toContain(`If running on saucelabs, perhaps you're out of capacity and should TRY RUN AGAIN LATER :)`);
+      done();
+    }, 0)
+
   })
 
+  test('should exclude text that is not white listed', (done) => {
+    const cp = new ChildProcess(newHandler());
 
-  test('should exclude text that is not white listed', () => {
-    const cp = new ChildProcess(handler);
+    cp.handler.stdout.end('This text is not white listed');
 
-    cp.onDataCallback('This text is not white listed')
+    setTimeout(() => {
+      expect(cp.stdout.trim().endsWith('Magellan child process start')).toEqual(true)
+      done();
+    }, 0)
 
-    expect(cp.stdout.trim().endsWith('Magellan child process start')).toEqual(true)
   })
 
-  test('should not exclude any text if env.debug is true', () => {
+  test('should not exclude any text if env.debug is true', (done) => {
     process.env.DEBUG = true
-    const cp = new ChildProcess(handler);
+    const cp = new ChildProcess(newHandler());
 
-    cp.onDataCallback('This text is not white listed')
+    cp.handler.stdout.end('This text is not white listed');
 
-    expect(cp.stdout.trim().endsWith('Magellan child process start')).toEqual(false)
+    setTimeout(() => {
+      expect(cp.stdout.trim().endsWith('Magellan child process start')).toEqual(false)
+      done();
+    }, 0)
+
   })
-
 
 });


### PR DESCRIPTION
Quite simple, use pipes in the ChildProcess. 

This fixes a bug in where the reporters can be given the "unfiltered" nightwatch debug log, which is way to large for any reporter to deal with.

Cheers!

below is a screen of the bug this PR fixes

<img width="1416" alt="Screen Shot 2020-08-26 at 1 19 58 PM" src="https://user-images.githubusercontent.com/1024460/91364158-fa6f1400-e7b2-11ea-89ac-69273e89a976.png">
