### PR TITLE
made-whitelist-more-specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan",
-  "version": "11.0.12",
+  "version": "11.0.13",
   "description": "Massively parallel automated testing",
   "main": "src/main",
   "directories": {

--- a/src/util/childProcess.js
+++ b/src/util/childProcess.js
@@ -29,7 +29,12 @@ const ADDED_ERROR_MESSAGE_CONTEXT = "If running on saucelabs, perhaps " +
 
 // if the "this.handler.stdout" stream of the childprocess does not
 // include atleast one of these tokens then it will not be included in the "this.stdout"
-const STDOUT_WHITE_LIST = ["ERROR", "WARN", "Test Suite", "✖"];
+const STDOUT_WHITE_LIST = [
+  "\x1B[1;33mERROR\x1B[0m",
+  "\x1B[1;32m\x1B[40mWARN\x1B[0m",
+  "Test Suite",
+  "✖"
+];
 
 // we slice the VERBOSE nighwatch stdout stream on the purple INFO text that has black background
 const SLICE_ON_TEXT = "\x1B[1;35m\x1B[40mINFO\x1B[0m";

--- a/test/utils/child_process.test.js
+++ b/test/utils/child_process.test.js
@@ -62,16 +62,15 @@ describe('Child process', () => {
     cp.teardown();
   });
 
-  test('should append data to stdout', (done) => {
+  test('should append data to stdout if contains whitelisted data', (done) => {
     const cp = new ChildProcess(newHandler());
 
-    cp.handler.stdout.write('WARN fake data');
-    cp.handler.stdout.end('WARN real data');
+    const warnTag = '\x1B[1;32m\x1B[40mWARN\x1B[0m'
+    cp.handler.stdout.end(`${warnTag} sample data`);
 
     // wait for the write to flow thru the slicer and filter transforms
     setTimeout(() => {
-      expect(cp.stdout).toContain('fake data');
-      expect(cp.stdout).toContain('real data');
+      expect(cp.stdout).toContain(`${warnTag} sample data`);
       done();
     }, 0)
 
@@ -80,7 +79,8 @@ describe('Child process', () => {
   test('should add context to error message', (done) => {
     const cp = new ChildProcess(newHandler());
 
-    cp.handler.stdout.end('ERROR Connection refused! Is selenium server started?');
+    const errorTag = '\x1B[1;33mERROR\x1B[0m';
+    cp.handler.stdout.end(`${errorTag} Connection refused! Is selenium server started?`);
 
     // wait for the write to flow thru the slicer and filter transforms
     setTimeout(() => {


### PR DESCRIPTION
users are having issue with the logging being too verbose.

this has been fix by making the whitelist be more "specific" ... "error" and "warn" strings are too generic.

the new white list should filter only what we need